### PR TITLE
feat(HACBS-1823): copy index image produced by IIB to final signed public location

### DIFF
--- a/catalog/pipeline/fbc-release/0.9/README.md
+++ b/catalog/pipeline/fbc-release/0.9/README.md
@@ -1,0 +1,62 @@
+# FBC Release Pipeline
+
+ Tekton release pipeline to interact with FBC Pipeline                       
+
+## Parameters
+
+| Name | Description | Optional | Default value |
+|------|-------------|----------|---------------|
+| snapshot | The Snapshot in JSON format | No | - |
+| enterpriseContractPolicy | JSON representation of the EnterpriseContractPolicy | No | - |
+| fromIndex | Index image (catalog of catalogs) the FBC fragment will be added to | No | - |
+| targetIndex | Index image (catalog of catalogs) the FBC fragment will be added to | No | - |
+| binaryImage | OCP binary image to be baked into the index image | Yes | "" |
+| buildTags | List of additional tags the internal index image copy should be tagged with | Yes | "[]" |
+| addArches | List of arches the index image should be built for | Yes | "[]" |
+| requester | Name of the user that requested the signing, for auditing purposes | No | - |
+| signingConfigMapName | The ConfigMap Name required by the Pipeline | Yes | "hacbs-signing-pipeline-config" |
+| fbcPublishingCredentials | Secret used to publish the built index image | Yes | "fbc-publishing-credentials" |
+| requestUpdateTimeout | Max seconds to wait until the status is updated | Yes | - |
+| buildTimeoutSeconds | Max seconds to wait until the build finishes | Yes | - |
+
+## Changelog
+
+### Changes since 0.8
+- fixes in the README.md file
+- adds param `fbcPublishingCredentials`
+- removes param `overwriteFromIndex`
+- adds new task `publish-index-image`
+
+### Changes since 0.7
+The syntax for `taskRef.bundle` and `pipelineRef.bundle` is deprecated,
+bundles resolver is used with new format.
+
+### Changes since 0.6
+- adds sign-index-image task
+- refactor task and change its reference name from `create-internal-request`
+  to `add-fbc-contribution-to-index-image`
+- adds `requester` and `signingConfigMapName` parameters
+- removes `resolvedIndexImage` result
+
+### Changes since 0.5
+- updates `create-internal-request` task version to 0.3
+
+### Changes since 0.4
+- updates `create-internal-request` task version to 0.2
+- adds `resolvedIndexImage` result
+
+### Changes since 0.3
+- removes param `fbcFragment`
+- adds param `buildTimeoutSeconds`
+
+### Changes since 0.2
+- renames the pipeline to `fbc-release`
+- forces the pipeline to run after `verify-enterprise-contract`
+
+### Changes since 0.1
+- adds param `requestUpdateTimeout`
+- adds task result values to the pipeline results
+  - `requestMessage` gets `$(tasks.create-internal-request.results.requestMessage)`
+  - `requestReason` gets `$(tasks.create-internal-request.results.requestReason)`
+  - `requestResults` gets `$(tasks.create-internal-request.results.requestResults)`
+- changes `verify-enterprise-contract` task version

--- a/catalog/pipeline/fbc-release/0.9/fbc-release.yaml
+++ b/catalog/pipeline/fbc-release/0.9/fbc-release.yaml
@@ -1,0 +1,157 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: fbc-release
+  labels:
+    app.kubernetes.io/version: "0.9"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Tekton release pipeline to interact with FBC Pipeline
+  params:
+    - name: snapshot
+      type: string
+      description: The Snapshot in JSON format
+    - name: enterpriseContractPolicy
+      type: string
+      description: JSON representation of the EnterpriseContractPolicy
+    - name: fromIndex
+      type: string
+      description: The source Index image (catalog of catalogs) FBC fragment
+    - name: targetIndex
+      type: string
+      description: Index image (catalog of catalogs) the FBC fragment will be added to
+    - name: binaryImage
+      type: string
+      default: ""
+      description: OCP binary image to be baked into the index image
+    - name: buildTags
+      type: string
+      default: "[]"
+      description: List of additional tags the internal index image copy should be tagged with
+    - name: addArches
+      type: string
+      default: "[]"
+      description: List arches to be added to be built
+    - name: requester
+      type: string
+      description: Name of the user that requested the signing, for auditing purposes
+    - name: signingConfigMapName
+      type: string
+      default: "hacbs-signing-pipeline-config"
+      description: The ConfigMap to be used by the signing Pipeline
+    - name: fbcPublishingCredentials
+      type: string
+      default: "fbc-publishing-credentials"
+      description: Secret used to publish the built index image
+    - name: requestUpdateTimeout
+      type: string
+      description: Max seconds to wait until the status is updated
+    - name: buildTimeoutSeconds
+      type: string
+      description: Max seconds to wait until the build finishes
+  results:
+    - name: requestMessage
+      value: $(tasks.publish-index-image.results.requestMessage)
+    - name: requestReason
+      value: $(tasks.add-fbc-contribution-to-index-image.results.requestReason)
+    - name: requestResults
+      value: $(tasks.add-fbc-contribution-to-index-image.results.requestResults)
+  tasks:
+    - name: verify-enterprise-contract
+      taskRef:
+        resolver: "bundles"
+        params:
+          - name: bundle
+            value: quay.io/hacbs-contract/ec-task-bundle:snapshot
+          - name: kind
+            value: task
+          - name: name
+            value: verify-enterprise-contract
+      params:
+        - name: IMAGES
+          value: $(params.snapshot)
+        - name: SSL_CERT_DIR
+          value: /var/run/secrets/kubernetes.io/serviceaccount
+        - name: POLICY_CONFIGURATION
+          value: $(params.enterpriseContractPolicy)
+        - name: STRICT
+          value: "1"
+    - name: add-fbc-contribution-to-index-image
+      taskRef:
+        resolver: "bundles"
+        params:
+          - name: bundle
+            value: quay.io/hacbs-release/task-create-internal-request:0.4
+          - name: kind
+            value: task
+          - name: name
+            value: create-internal-request
+      params:
+        - name: pipelineRunName
+          value: $(context.pipelineRun.name)
+        - name: fbcFragment
+          value: $(params.snapshot)
+        - name: fromIndex
+          value: $(params.fromIndex)
+        - name: overwriteFromIndex
+          value: "true"
+        - name: binaryImage
+          value: $(params.binaryImage)
+        - name: buildTags
+          value: $(params.buildTags)
+        - name: addArches
+          value: $(params.addArches)
+        - name: requestUpdateTimeout
+          value: $(params.requestUpdateTimeout)
+        - name: buildTimeoutSeconds
+          value: $(params.buildTimeoutSeconds)
+      runAfter:
+        - verify-enterprise-contract
+    - name: sign-index-image
+      taskRef:
+        resolver: "bundles"
+        params:
+          - name: bundle
+            value: quay.io/hacbs-release/task-sign-index-image:0.1
+          - name: kind
+            value: task
+          - name: name
+            value: sign-index-image
+      params:
+        - name: pipelineRunName
+          value: $(context.pipelineRun.name)
+        - name: requestJsonResults
+          value: $(tasks.add-fbc-contribution-to-index-image.results.requestResults)
+        - name: targetIndex
+          value: $(params.targetIndex)
+        - name: requester
+          value: $(params.requester)
+        - name: configMapName
+          value: $(params.signingConfigMapName)
+        - name: requestUpdateTimeout
+          value: $(params.requestUpdateTimeout)
+    - name: publish-index-image
+      taskRef:
+        resolver: "bundles"
+        params:
+          - name: bundle
+            value: quay.io/hacbs-release/task-publish-index-image:0.1
+          - name: kind
+            value: task
+          - name: name
+            value: publish-index-image
+      params:
+        - name: requestJsonResults
+          value: $(tasks.add-fbc-contribution-to-index-image.results.requestResults)
+        - name: targetIndex
+          value: $(params.targetIndex)
+        - name: retries
+          value: "0"
+        - name: fbcPublishingCredentials
+          value: $(params.fbcPublishingCredentials)
+      runAfter:
+        - sign-index-image

--- a/catalog/pipeline/fbc-release/0.9/samples/sample_release_PipelineRun.yaml
+++ b/catalog/pipeline/fbc-release/0.9/samples/sample_release_PipelineRun.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: fbc-release-run-empty-params
+spec:
+  params:
+    - name: snapshot
+      value: ""
+    - name: enterpriseContractPolicy
+      value: ""
+    - name: fromIndex
+      value: ""
+    - name: targetIndex
+      value: ""
+    - name: binaryImage
+      value: ""
+    - name: buildTags
+      value: ""
+    - name: addArches
+      value: ""
+    - name: requester
+      value: ""
+    - name: signingConfigMapName
+      value: ""
+    - name: fbcPublishingCredentials
+      value: ""
+  pipelineRef:
+    resolver: "bundles"
+    params: 
+      - name: bundle
+        value: quay.io/hacbs-release/pipeline-fbc-release:0.9
+      - name: kind
+        value: pipeline
+      - name: name
+        value: fbc-release

--- a/catalog/pipeline/fbc-release/0.9/tests/run.yaml
+++ b/catalog/pipeline/fbc-release/0.9/tests/run.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: fbc-release-run-empty-params
+spec:
+  params:
+    - name: snapshot
+      value: ""
+    - name: enterpriseContractPolicy
+      value: ""
+    - name: fromIndex
+      value: ""
+    - name: targetIndex
+      value: ""
+    - name: binaryImage
+      value: ""
+    - name: buildTags
+      value: ""
+    - name: addArches
+      value: ""
+    - name: requester
+      value: ""
+    - name: signingConfigMapName
+      value: ""
+    - name: fbcPublishingCredentials
+      value: ""
+  pipelineRef:
+    resolver: "bundles"
+    params: 
+      - name: bundle
+        value: quay.io/hacbs-release/pipeline-fbc-release:0.9
+      - name: kind
+        value: pipeline
+      - name: name
+        value: fbc-release

--- a/catalog/task/publish-index-image/0.1/README.md
+++ b/catalog/task/publish-index-image/0.1/README.md
@@ -1,0 +1,14 @@
+# publish-index-image
+
+Publish a built FBC index image using skopeo
+
+## Parameters
+
+| Name | Description | Optional | Default value |
+|------|-------------|----------|---------------|
+| requestJsonResults | The JSON result of the IIB build internal request | No | |
+| targetIndex | targetIndex signing image | No | |
+| retries | Number of skopeo retries | Yes | "0" |
+| publishingCredentials | The credentials used to access the registries | Yes | "fbc-publishing-credentials" |
+| requestUpdateTimeout | Max seconds waiting for the status update | Yes | 360 |
+

--- a/catalog/task/publish-index-image/0.1/publish-index-image.yaml
+++ b/catalog/task/publish-index-image/0.1/publish-index-image.yaml
@@ -1,0 +1,74 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: publish-index-image
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+      Publish a built FBC index image using skopeo
+  params:
+    - name: requestJsonResults
+      type: string
+      description: The JSON result of the IIB build internal request
+    - name: targetIndex
+      type: string
+      description: targetIndex signing image
+    - name: retries
+      type: string
+      default: "0"
+      description: Number of skopeo retries
+    - name: publishingCredentials
+      type: string
+      default: "fbc-publishing-credentials"
+      description: The credentials used to access the registries
+    - name: requestUpdateTimeout
+      type: string
+      default: "360"
+      description: Max seconds waiting for the status update
+  results:
+    - name: requestMessage
+  steps:
+    - name: publish-index-image
+      env:
+        - name: SOURCE_INDEX_CREDENTIAL
+          valueFrom:
+            secretKeyRef:
+              key: sourceIndexCredential
+              name: $(params.publishingCredentials)
+        - name: TARGET_INDEX_CREDENTIAL
+          valueFrom:
+            secretKeyRef:
+              key: targetIndexCredential
+              name: $(params.publishingCredentials)
+      image: >-
+        quay.io/hacbs-release/release-base-image@sha256:9e7fd1a3ccf0d2c8077f565c78e50862a7cc4792d548b5c01c8b09077e6d23a7
+      script: |
+        #!/usr/bin/env sh
+        PATH=/bin:/usr/bin:/usr/local/bin
+        export PATH
+
+        set -e
+        jsonInputFile="/tmp/$$.json"
+        cat > ${jsonInputFile} <<JSON
+        $(params.requestJsonResults)
+        JSON
+
+        indexImageResolved=`jq -cr .jsonBuildInfo ${jsonInputFile} \
+        | jq -cr .index_image_resolved`
+
+        (skopeo copy \
+        --all \
+        --preserve-digests \
+        --retry-times "$(params.retries)" \
+        --src-tls-verify=false \
+        --src-creds "${SOURCE_INDEX_CREDENTIAL}" \
+        "docker://${indexImageResolved}" \
+        --dest-creds "${TARGET_INDEX_CREDENTIAL}" \
+        "docker://$(params.targetIndex)" && \
+        echo "Index Image Published successfully" || \
+        echo "Failed publishing Index Image") | tee $(results.requestMessage.path)

--- a/catalog/task/publish-index-image/0.1/samples/publish-index-image_TaskRun.yaml
+++ b/catalog/task/publish-index-image/0.1/samples/publish-index-image_TaskRun.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: publish-index-image-run-empty-params
+spec:
+  params:
+    - name: requestJsonResults
+      value: ""
+    - name: targetIndex
+      value: ""
+  taskRef:
+    resolver: "bundles"
+    params:
+      - name: bundle
+        value: quay.io/hacbs-release/task-publish-index-image:0.1
+      - name: kind
+        value: task
+      - name: name
+        value: publish-index-image

--- a/catalog/task/publish-index-image/0.1/tests/run.yaml
+++ b/catalog/task/publish-index-image/0.1/tests/run.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: publish-index-image-run-empty-params
+spec:
+  params:
+    - name: requestJsonResults
+      value: ""
+    - name: targetIndex
+      value: ""
+  taskRef:
+    resolver: "bundles"
+    params:
+      - name: bundle
+        value: quay.io/hacbs-release/task-publish-index-image:0.1
+      - name: kind
+        value: task
+      - name: name
+        value: publish-index-image

--- a/catalog/task/publish-index-image/OWNERS
+++ b/catalog/task/publish-index-image/OWNERS
@@ -1,0 +1,1 @@
+hacbs-release@redhat.com


### PR DESCRIPTION
FBC Pipeline should copy the signed index image produced by IIB to the final public location

Signed-off-by: Leandro Mendes <lmendes@redhat.com>