### PR TITLE
chore(HACBS-1614): release-bundles repo rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # HACBS Release bundles
 
-HACBS Release bundles is a curated Tekton bundles catalog that contains bundles that are used by the
-[HACBS Release operator](https://github.com/redhat-appstudio/release-service) to process releases in the context of
+Release service bundles is a curated Tekton bundles catalog that contains bundles that are used by the
+[Appstudio Release operator](https://github.com/redhat-appstudio/release-service) to process releases in the context of
 AppStudio.
 
 ## Using the bundles


### PR DESCRIPTION
hacbs-release/release-bundles was moved to
redhat-appstudio/release-service-bundles. This commit updates the README to be a little more clear given this change.