### PR TITLE
chore: upgrade tkn version on action

### DIFF
--- a/.github/workflows/tekton_bundle_push.yaml
+++ b/.github/workflows/tekton_bundle_push.yaml
@@ -32,6 +32,8 @@ jobs:
         run: .github/scripts/mock_kube_config.sh
         shell: bash
       - uses: jerop/tkn@v0.1.0
+        with:
+          version: v0.26.0
       - uses: redhat-actions/podman-login@v1
         with:
           username: ${{ env.REGISTRY_USER }}


### PR DESCRIPTION
tkn  v0.18 can't parse the fbc-release.yaml after `create-internal-request` change, but newer can.

- upgrades to `v0.26.0`

Signed-off-by: Leandro Mendes <lmendes@redhat.com>