### PR TITLE
feat(HACBS-1554): add push-sbom-to-pyxis task to push-to-external-registry

### DIFF
--- a/catalog/pipeline/push-to-external-registry/0.7/README.md
+++ b/catalog/pipeline/push-to-external-registry/0.7/README.md
@@ -1,0 +1,45 @@
+# Push to External Registry Pipeline
+
+Tekton pipeline to push images to an external registry.
+
+## Parameters
+
+| Name | Description | Optional | Default value |
+|------|-------------|----------|---------------|
+| snapshot | The Snapshot in JSON format | No | - |
+| enterpriseContractPolicy | JSON representation of the policy to be applied when validating the enterprise contract | No | - |
+| extraConfigGitUrl |URL to the remote Git repository containing the extra config | No | - |
+| extraConfigGitRevision | Revision to fetch from the remote Git repository containing the extra config | No | - |
+| extraConfigPath | Path to the extra config file within the repository | No | - |
+| tag | The default tag to use when mapping file does not contain a tag | No | - |
+| addGitShaTag | When pushing the snapshot components, also push a tag with the image git sha | Yes | false |
+| addSourceShaTag | When pushing the snapshot components, also push a tag with the image source sha | Yes | true |
+| addTimestampTag | When pushing the snapshot components, also push a tag with the current timestamp | Yes | false |
+| pyxisServerType | The Pyxis server type to use. Options are 'production' and 'stage' | No | - |
+| pyxisSecret | The kubernetes secret to use to authenticate to Pyxis. It needs to contain two keys: key and cert | No | - |
+| postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
+
+## Changes since 0.5
+The syntax for `taskRef.bundle` and `pipelineRef.bundle` is deprecated,
+bundles resolver is used with new format.
+
+## Changes since 0.4
+* Upgrade push-snapshot task to version 0.6
+  * addShaTag parameter is now named addSourceShaTag
+  * addGitShaTag parameter is now supported and passed as a pipeline parameter to the task
+
+## Changes since 0.3
+
+* Upgrade push-snapshot task to version 0.5
+  * addShaTag parameter is now supported and passed as a pipeline parameter to the task
+  * addTimestampTag parameter is now supported and passed as a pipeline parameter to the task
+
+## Changes since 0.2
+
+* push-snapshot now supports tag parameter
+
+## Changes since 0.1
+
+* Upgrade create-pyxis-image task to version 0.2
+  * correct incorrect snapshot param
+

--- a/catalog/pipeline/push-to-external-registry/0.7/README.md
+++ b/catalog/pipeline/push-to-external-registry/0.7/README.md
@@ -19,6 +19,10 @@ Tekton pipeline to push images to an external registry.
 | pyxisSecret | The kubernetes secret to use to authenticate to Pyxis. It needs to contain two keys: key and cert | No | - |
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 
+## Changes since 0.6
+Add `push-sbom-to-pyxis` task to the pipeline. This will ensure that sbom components
+for the image are pushed to Pyxis as part of this pipeline.
+
 ## Changes since 0.5
 The syntax for `taskRef.bundle` and `pipelineRef.bundle` is deprecated,
 bundles resolver is used with new format.

--- a/catalog/pipeline/push-to-external-registry/0.7/push-to-external-registry.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.7/push-to-external-registry.yaml
@@ -1,0 +1,194 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: push-to-external-registry
+  labels:
+    app.kubernetes.io/version: "0.6"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Tekton pipeline to release HACBS Snapshot to Quay
+  params:
+    - name: snapshot
+      type: string
+      description: The Snapshot in JSON format
+    - name: enterpriseContractPolicy
+      type: string
+      description: JSON representation of the EnterpriseContractPolicy
+    - name: extraConfigGitUrl
+      type: string
+      description: URL to the remote Git repository containing the extra config
+      default: ""
+    - name: extraConfigGitRevision
+      type: string
+      description: Revision to fetch from the remote Git repository containing the extra config
+      default: ""
+    - name: extraConfigPath
+      type: string
+      description: Path to the extra config file within the repository
+      default: ""
+    - name: tag
+      type: string
+      description: The default tag to use when mapping file does not contain a tag
+    - name: addGitShaTag
+      type: string
+      description: When pushing the snapshot components, also push a tag with the image git sha
+      default: "false"
+    - name: addSourceShaTag
+      type: string
+      description: When pushing the snapshot components, also push a tag with the image source sha
+      default: "true"
+    - name: addTimestampTag
+      type: string
+      description: When pushing the snapshot components, also push a tag with the current timestamp
+      default: "false"
+    - name: pyxisServerType
+      type: string
+      description: The Pyxis server type to use. Options are 'production' and 'stage'
+    - name: pyxisSecret
+      type: string
+      description: |
+        The kubernetes secret to use to authenticate to Pyxis. It needs to contain two keys: key and cert
+    - name: postCleanUp
+      type: string
+      description: Cleans up workspace after finishing executing the pipeline
+      default: "true"
+  workspaces:
+    - name: release-workspace
+  tasks:
+    - name: clone-config-file
+      taskRef:
+        resolver: "bundles"
+        params:
+          - name: bundle
+            value: quay.io/redhat-appstudio/appstudio-tasks:583d33c8ddf0de2ea8e1a73d94a1ca4a6e6ed380-1
+          - name: kind
+            value: task
+          - name: name
+            value: git-clone
+      when:
+        - input: $(params.extraConfigGitUrl)
+          operator: notin
+          values: [""]
+      params:
+        - name: url
+          value: $(params.extraConfigGitUrl)
+        - name: revision
+          value: $(params.extraConfigGitRevision)
+        - name: subdirectory
+          value: "$(context.pipelineRun.uid)"
+      workspaces:
+        - name: output
+          workspace: release-workspace
+    - name: apply-mapping
+      taskRef:
+        resolver: "bundles"
+        params:
+          - name: bundle
+            value: quay.io/hacbs-release/task-apply-mapping:0.3
+          - name: kind
+            value: task
+          - name: name
+            value: apply-mapping
+      params:
+        - name: snapshot
+          value: $(params.snapshot)
+        - name: extraConfigPath
+          value: "$(context.pipelineRun.uid)/$(params.extraConfigPath)"
+      when:
+        - input: $(tasks.clone-config-file.results.commit)
+          operator: notin
+          values: [""]
+      workspaces:
+        - name: config
+          workspace: release-workspace
+    - name: verify-enterprise-contract
+      taskRef:
+        resolver: "bundles"
+        params:
+          - name: bundle
+            value: quay.io/hacbs-contract/ec-task-bundle:snapshot
+          - name: kind
+            value: task
+          - name: name
+            value: verify-enterprise-contract
+      params:
+        - name: IMAGES
+          value: $(tasks.apply-mapping.results.snapshot)
+        - name: SSL_CERT_DIR
+          value: /var/run/secrets/kubernetes.io/serviceaccount
+        - name: POLICY_CONFIGURATION
+          value: $(params.enterpriseContractPolicy)
+        - name: STRICT
+          value: "1"
+    - name: push-snapshot
+      taskRef:
+        resolver: "bundles"
+        params:
+          - name: bundle
+            value: quay.io/hacbs-release/task-push-snapshot:0.6
+          - name: kind
+            value: task
+          - name: name
+            value: push-snapshot
+      params:
+        - name: mappedSnapshot
+          value: $(tasks.apply-mapping.results.snapshot)
+        - name: tag
+          value: $(params.tag)
+        - name: addGitShaTag
+          value: $(params.addGitShaTag)
+        - name: addSourceShaTag
+          value: $(params.addSourceShaTag)
+        - name: addTimestampTag
+          value: $(params.addTimestampTag)
+      runAfter:
+        - verify-enterprise-contract
+    - name: create-pyxis-image
+      taskRef:
+        resolver: "bundles"
+        params:
+          - name: bundle
+            value: quay.io/hacbs-release/task-create-pyxis-image:0.3
+          - name: kind
+            value: task
+          - name: name
+            value: create-pyxis-image
+      params:
+        - name: server
+          value: $(params.pyxisServerType)
+        - name: pyxisSecret
+          value: $(params.pyxisSecret)
+        - name: tag
+          value: $(params.tag)
+        - name: mappedSnapshot
+          value: $(tasks.apply-mapping.results.snapshot)
+      runAfter:
+        - push-snapshot
+  finally:
+    - name: cleanup
+      taskRef:
+        resolver: "bundles"
+        params:
+          - name: bundle
+            value: quay.io/hacbs-release/task-cleanup-workspace:0.2
+          - name: kind
+            value: task
+          - name: name
+            value: cleanup-workspace
+      when:
+        - input: $(params.postCleanUp)
+          operator: in
+          values: ["true"]
+        - input: $(params.extraConfigGitUrl)
+          operator: notin
+          values: [""]
+      params:
+        - name: subdirectory
+          value: "$(context.pipelineRun.uid)"
+      workspaces:
+        - name: input
+          workspace: release-workspace

--- a/catalog/pipeline/push-to-external-registry/0.7/push-to-external-registry.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.7/push-to-external-registry.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: push-to-external-registry
   labels:
-    app.kubernetes.io/version: "0.6"
+    app.kubernetes.io/version: "0.7"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -168,6 +168,25 @@ spec:
           value: $(tasks.apply-mapping.results.snapshot)
       runAfter:
         - push-snapshot
+    - name: push-sbom-to-pyxis
+      taskRef:
+        resolver: "bundles"
+        params:
+          - name: bundle
+            value: quay.io/hacbs-release/task-push-sbom-to-pyxis:0.1
+          - name: kind
+            value: task
+          - name: name
+            value: push-sbom-to-pyxis
+      params:
+        - name: mappedSnapshot
+          value: $(tasks.apply-mapping.results.snapshot)
+        - name: containerImageIDs
+          value: $(tasks.create-pyxis-image.results.containerImageIDs)
+        - name: server
+          value: $(params.pyxisServerType)
+        - name: pyxisSecret
+          value: $(params.pyxisSecret)
   finally:
     - name: cleanup
       taskRef:

--- a/catalog/pipeline/push-to-external-registry/0.7/samples/sample_push-to-external-registry_PipelineRun.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.7/samples/sample_push-to-external-registry_PipelineRun.yaml
@@ -25,9 +25,9 @@ spec:
       value: ""
   pipelineRef:
     resolver: "bundles"
-    params: 
+    params:
       - name: bundle
-        value: quay.io/hacbs-release/pipeline-push-to-external-registry:0.6
+        value: quay.io/hacbs-release/pipeline-push-to-external-registry:0.7
       - name: kind
         value: pipeline
       - name: name

--- a/catalog/pipeline/push-to-external-registry/0.7/samples/sample_push-to-external-registry_PipelineRun.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.7/samples/sample_push-to-external-registry_PipelineRun.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: push-to-external-registry-run-empty-params
+spec:
+  params:
+    - name: snapshot
+      value: ""
+    - name: enterpriseContractPolicy
+      value: ""
+    - name: extraConfigGitUrl
+      value: ""
+    - name: extraConfigGitRevision
+      value: ""
+    - name: extraConfigPath
+      value: ""
+    - name: pyxisServerType
+      value: ""
+    - name: pyxisSecret
+      value: ""
+    - name: tag
+      value: ""
+    - name: postCleanUp
+      value: ""
+  pipelineRef:
+    resolver: "bundles"
+    params: 
+      - name: bundle
+        value: quay.io/hacbs-release/pipeline-push-to-external-registry:0.6
+      - name: kind
+        value: pipeline
+      - name: name
+        value: push-to-external-registry

--- a/catalog/pipeline/push-to-external-registry/0.7/tests/run.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.7/tests/run.yaml
@@ -25,9 +25,9 @@ spec:
       value: ""
   pipelineRef:
     resolver: "bundles"
-    params: 
+    params:
       - name: bundle
-        value: quay.io/hacbs-release/pipeline-push-to-external-registry:0.6
+        value: quay.io/hacbs-release/pipeline-push-to-external-registry:0.7
       - name: kind
         value: pipeline
       - name: name

--- a/catalog/pipeline/push-to-external-registry/0.7/tests/run.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.7/tests/run.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: push-to-external-registry-run-empty-params
+spec:
+  params:
+    - name: snapshot
+      value: ""
+    - name: enterpriseContractPolicy
+      value: ""
+    - name: extraConfigGitUrl
+      value: ""
+    - name: extraConfigGitRevision
+      value: ""
+    - name: extraConfigPath
+      value: ""
+    - name: pyxisServerType
+      value: ""
+    - name: pyxisSecret
+      value: ""
+    - name: tag
+      value: ""
+    - name: postCleanUp
+      value: ""
+  pipelineRef:
+    resolver: "bundles"
+    params: 
+      - name: bundle
+        value: quay.io/hacbs-release/pipeline-push-to-external-registry:0.6
+      - name: kind
+        value: pipeline
+      - name: name
+        value: push-to-external-registry

--- a/catalog/task/push-sbom-to-pyxis/0.1/README.md
+++ b/catalog/task/push-sbom-to-pyxis/0.1/README.md
@@ -1,12 +1,12 @@
 # push-sbom-to-pyxis
 
-Tekton task that extracts sbom from a pull spec and pushes it to Pyxis.
+Tekton task that extracts sboms from pull specs and pushes them to Pyxis.
 
 ## Parameters
 
 | Name | Description | Optional | Default value |
 |------|-------------|----------|---------------|
-| imageURLs | Space separated list of binary image URLs that are used to obtain SBOMs via cosign | No | - |
+| mappedSnapshot | The mapped snapshot in JSON format | No | - |
 | containerImageIDs | Space separated list of Pyxis image IDs | No | - |
 | pyxisSecret | The kubernetes secret to use to authenticate to Pyxis. It needs to contain two keys: key and cert | No | - |
 | server | The server type to use. Options are 'production' and 'stage' | Yes | production |

--- a/catalog/task/push-sbom-to-pyxis/0.1/push-sbom-to-pyxis.yaml
+++ b/catalog/task/push-sbom-to-pyxis/0.1/push-sbom-to-pyxis.yaml
@@ -10,10 +10,10 @@ metadata:
     tekton.dev/tags: release
 spec:
   description: >-
-    Tekton task that extracts sbom from a pull spec and pushes it to Pyxis.
+    Tekton task that extracts sboms from pull specs and pushes them to Pyxis.
   params:
-    - name: imageURLs
-      description: Space separated list of binary image URLs that are used to obtain SBOMs via cosign
+    - name: mappedSnapshot
+      description: The mapped snapshot in JSON format
       type: string
     - name: containerImageIDs
       description: Space separated list of Pyxis image IDs
@@ -40,7 +40,7 @@ spec:
         #!/usr/bin/env sh
         set -eux
 
-        IMAGEURLS=($(params.imageURLs))
+        IMAGEURLS=($(jq -r '.components[].repository' <<< '$(params.mappedSnapshot)'))
         IMAGEIDS=($(params.containerImageIDs))
 
         if [ ${#IMAGEURLS[@]} != ${#IMAGEIDS[@]} ]; then

--- a/catalog/task/push-sbom-to-pyxis/0.1/sample/sample_push-sbom-to-pyxis_TaskRun.yaml
+++ b/catalog/task/push-sbom-to-pyxis/0.1/sample/sample_push-sbom-to-pyxis_TaskRun.yaml
@@ -5,7 +5,7 @@ metadata:
   name: push-sbom-to-pyxis-run-empty-params
 spec:
   params:
-    - name: imageURLs
+    - name: mappedSnapshot
       value: ""
     - name: containerImageIDs
       value: ""

--- a/catalog/task/push-sbom-to-pyxis/0.1/tests/run.yaml
+++ b/catalog/task/push-sbom-to-pyxis/0.1/tests/run.yaml
@@ -5,7 +5,7 @@ metadata:
   name: push-sbom-to-pyxis-run-empty-params
 spec:
   params:
-    - name: imageURLs
+    - name: mappedSnapshot
       value: ""
     - name: containerImageIDs
       value: ""


### PR DESCRIPTION
This will ensure that sbom components for the image are pushed to Pyxis as part of this pipeline.

Also, modify push-sbom-to-pyxis task to use mappedSnapshot instead of image urls as a parameter - we don't have the urls ready in the pipeline, so we'll have to get them from the snapshot.

Note that while this PR is adding a new version of push-to-external-registry, the push-sbom-to-pyxis task remains at version 0.1 since it's not used anywhere yet, so there shouldn't be any need for a new version.