### PR TITLE
fix(HACBS-2139): install tkn directly in gh workflow

### DIFF
--- a/.github/workflows/tekton_bundle_push.yaml
+++ b/.github/workflows/tekton_bundle_push.yaml
@@ -14,12 +14,13 @@ env:
   REGISTRY_USER: ${{ secrets.QUAY_ROBOT_USER }}
   REGISTRY_PASSWORD: ${{ secrets.QUAY_ROBOT_TOKEN }}
   API_TOKEN: ${{ secrets.QUAY_API_TOKEN }}
+  TKN_CLI_VERSION: 0.30.1
 jobs:
   run-pipeline:
     name: Tekton Bundle
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0  # ∈(2,0) where 0 = all history, and 2 is the minimum.
       - name: Get changed files
@@ -31,9 +32,10 @@ jobs:
       - name: Create mock kube config
         run: .github/scripts/mock_kube_config.sh
         shell: bash
-      - uses: jerop/tkn@v0.1.0
-        with:
-          version: v0.26.0
+      - name: Install tkn
+        run: |
+          curl -LO "https://github.com/tektoncd/cli/releases/download/v${TKN_CLI_VERSION}/tektoncd-cli-${TKN_CLI_VERSION}_Linux-64bit.deb"
+          sudo dpkg -i ./tektoncd-cli-${TKN_CLI_VERSION}_Linux-64bit.deb
       - uses: redhat-actions/podman-login@v1
         with:
           username: ${{ env.REGISTRY_USER }}


### PR DESCRIPTION
The action that was used hasn't been updated
in years and it's just two commands, so it makes
sense to install tkn directly rather than rely
on a community action.

Also, update the checkout action to v3. v2 is deprecated.

Note that I tested both the updated checkout action and the new install tkn step in a custom workflow here: https://github.com/mmalina/release-service-bundles/actions/runs/4785630080