### PR TITLE
fix: update changed-files version in workflow

### DIFF
--- a/.github/workflows/tekton_bundle_push.yaml
+++ b/.github/workflows/tekton_bundle_push.yaml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0  # ∈(2,0) where 0 = all history, and 2 is the minimum.
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v22.2
+        uses: tj-actions/changed-files@v35
         with:
           files: |
             catalog/*/*/*/*.yaml


### PR DESCRIPTION
There were a bunch of warnings when running the old version of the action:

- Node.js 12 actions are deprecated.
- The `set-output` command is deprecated and will be disabled soon.

Updating to the newer version fixes this.

You can see the warnings here: https://github.com/redhat-appstudio/release-service-bundles/actions/runs/4794813297

And here's a test run in my fork with the updated version and without warnings (and it showed a modified file correctly): https://github.com/mmalina/release-service-bundles/actions/runs/4795256134