### PR TITLE
fix: use containerImage instead of repository to fetch sbom

### DIFF
--- a/catalog/task/push-sbom-to-pyxis/0.1/push-sbom-to-pyxis.yaml
+++ b/catalog/task/push-sbom-to-pyxis/0.1/push-sbom-to-pyxis.yaml
@@ -40,7 +40,7 @@ spec:
         #!/usr/bin/env sh
         set -eux
 
-        IMAGEURLS=($(jq -r '.components[].repository' <<< '$(params.mappedSnapshot)'))
+        IMAGEURLS=($(jq -r '.components[].containerImage' <<< '$(params.mappedSnapshot)'))
         IMAGEIDS=($(params.containerImageIDs))
 
         if [ ${#IMAGEURLS[@]} != ${#IMAGEIDS[@]} ]; then
@@ -53,7 +53,7 @@ spec:
 
         for i in ${!IMAGEURLS[@]}; do
           echo "Fetching sbom for image: ${IMAGEURLS[$i]}"
-          cosign download sbom --output-file ${IMAGEIDS[$i]}.json ${IMAGEURLS[$i]}
+          cosign download sbom --output-file "${IMAGEIDS[$i]}.json" "${IMAGEURLS[$i]}"
         done
 
     - name: push-sbom-files-to-pyxis


### PR DESCRIPTION
Repository does not refer to a specific image in the registry, for that we need to use the containerImage parameter of the snapshot.

Here's an example of a component:
{"name":"dc-metro-map","containerImage":"quay.io/redhat-appstudio-qe/dcmetromap@sha256:8de2af658331295ae0401478a179b9b0e0b8fcacd5f6b20d507b12100e2648f7","repository":"quay.io/hacbs-release-tests/dcmetromap"}

FYI, this came up here: https://issues.redhat.com/browse/RHTAPBUGS-197

The underlying issue of the bug is different, but in the log I noticed that the `cosign download sbom` command is missing the image sha.