### PR TITLE
fix(RHTAPBUGS-197): pyxis graphql api url was incorrect

### DIFF
--- a/catalog/task/push-sbom-to-pyxis/0.1/push-sbom-to-pyxis.yaml
+++ b/catalog/task/push-sbom-to-pyxis/0.1/push-sbom-to-pyxis.yaml
@@ -79,10 +79,10 @@ spec:
 
         if [[ "$(params.server)" == "production" ]]
         then
-          export PYXIS_GRAPHQL_API="https://graphql-pyxis.api.redhat.com/"
+          export PYXIS_GRAPHQL_API="https://graphql-pyxis.api.redhat.com/graphql/"
         elif [[ "$(params.server)" == "stage" ]]
         then
-          export PYXIS_GRAPHQL_API="https://graphql-pyxis.preprod.api.redhat.com/"
+          export PYXIS_GRAPHQL_API="https://graphql-pyxis.preprod.api.redhat.com/graphql/"
         else
           echo "Invalid server parameter. Only 'production' and 'stage' are allowed."
           exit 1


### PR DESCRIPTION
It was missing the trailing /graphql/ - this was also missing in pyxis documentation but it turns out it was an oversight.

I tested the full script execution with the staging instance - it successfully created a manifest and all the components. For prod, I only verified that running the `get_image` query for a non-existing image returns `"Not found"` - that confirms that the api is working and that the user crt+key is also working (with a different one I get `"You don't have a sufficient role for the endpoint.`").