### PR TITLE
feat(HACBS-2140): add tkn check for PRs in release-service-bundles repo

### DIFF
--- a/.github/actions/install-tkn/action.yaml
+++ b/.github/actions/install-tkn/action.yaml
@@ -1,0 +1,11 @@
+name: Install tkn
+runs:
+  using: "composite"
+  steps:
+    - run: |
+        curl -LO "https://github.com/tektoncd/cli/releases/download/v${TKN_CLI_VERSION}/tektoncd-cli-${TKN_CLI_VERSION}_Linux-64bit.deb"
+        sudo dpkg -i ./tektoncd-cli-${TKN_CLI_VERSION}_Linux-64bit.deb
+      shell: bash
+      env:
+        TKN_CLI_VERSION: 0.30.1
+

--- a/.github/scripts/tkn_check_parse.sh
+++ b/.github/scripts/tkn_check_parse.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+REGISTRY="foo.bar/foo:bar"
+
+main() { 
+  TMPFILE=$(mktemp)
+  for file in ${CHANGED_FILES}; do
+      echo -en "Checking file ${file}..."
+      tkn bundle push  ${REGISTRY} ${file} >/dev/null 2> ${TMPFILE} || true
+      if ERROR=`grep -o "^Error.*failed to parse.*" ${TMPFILE}`; then
+          echo  ${ERROR} && exit 1
+      else
+          echo "Ok"
+      fi
+  done
+  rm -f $TMPFILE
+}
+
+main

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,3 +14,22 @@ jobs:
         uses: frenck/action-yamllint@v1
         with:
           path: catalog/
+  tknparse:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout files
+        uses: actions/checkout@v3
+      - name: install tkn
+        uses: ./.github/actions/install-tkn
+      - name: Get changed files
+        uses: tj-actions/changed-files@v35
+        id: changed-files
+        with:
+          files: |
+            catalog/*/*/*/*.yaml
+      - name: Run tkn util
+        run: .github/scripts/tkn_check_parse.sh
+        env:
+          CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+          GITHUB_SHA: ${{ github.sha }}
+          GITHUB_REFNAME: ${{ github.ref_name }}

--- a/.github/workflows/tekton_bundle_push.yaml
+++ b/.github/workflows/tekton_bundle_push.yaml
@@ -14,7 +14,6 @@ env:
   REGISTRY_USER: ${{ secrets.QUAY_ROBOT_USER }}
   REGISTRY_PASSWORD: ${{ secrets.QUAY_ROBOT_TOKEN }}
   API_TOKEN: ${{ secrets.QUAY_API_TOKEN }}
-  TKN_CLI_VERSION: 0.30.1
 jobs:
   run-pipeline:
     name: Tekton Bundle
@@ -33,9 +32,7 @@ jobs:
         run: .github/scripts/mock_kube_config.sh
         shell: bash
       - name: Install tkn
-        run: |
-          curl -LO "https://github.com/tektoncd/cli/releases/download/v${TKN_CLI_VERSION}/tektoncd-cli-${TKN_CLI_VERSION}_Linux-64bit.deb"
-          sudo dpkg -i ./tektoncd-cli-${TKN_CLI_VERSION}_Linux-64bit.deb
+        uses: ./.github/actions/install-tkn
       - uses: redhat-actions/podman-login@v1
         with:
           username: ${{ env.REGISTRY_USER }}


### PR DESCRIPTION
To avoid breaking the github action that publish the bundles, we need to
check that the new versions are properly parsed by the `tkn` version
used by the github action.

- adds script `tkn_check_parse.sh`
- updates the lint workflow adding the tkn check

Signed-off-by: Leandro Mendes <lmendes@redhat.com>