### PR TITLE
Use latest EC task in release pipeline definitions

### DIFF
--- a/catalog/pipeline/release/0.10/release.yaml
+++ b/catalog/pipeline/release/0.10/release.yaml
@@ -92,7 +92,7 @@ spec:
         resolver: "bundles"
         params:
           - name: bundle
-            value: quay.io/hacbs-contract/ec-task-bundle:7f2e25e9fc6c64c95238628b0b2bdbd1aeb79454
+            value: quay.io/hacbs-contract/ec-task-bundle:cf58b68b872dacbbcb2cc571efac135b2989d638
           - name: kind
             value: task
           - name: name

--- a/catalog/pipeline/release/0.9/release.yaml
+++ b/catalog/pipeline/release/0.9/release.yaml
@@ -74,7 +74,7 @@ spec:
     - name: verify-enterprise-contract
       taskRef:
         name: verify-enterprise-contract
-        bundle: quay.io/hacbs-contract/ec-task-bundle:7f2e25e9fc6c64c95238628b0b2bdbd1aeb79454
+        bundle: quay.io/hacbs-contract/ec-task-bundle:cf58b68b872dacbbcb2cc571efac135b2989d638
       params:
         - name: IMAGES
           value: $(tasks.apply-mapping.results.snapshot)


### PR DESCRIPTION
Still pinning it to a specific tag though, rather than using :snapshot.

The specific motivation for doing this now is this test failure:

  `invalid uri: uri missing scheme prefix`

The failure is related to this chains upstream PR: https://github.com/tektoncd/chains/pull/792 which has a workaround in https://github.com/enterprise-contract/ec-cli/pull/649 .

IIUC updating the task bundle should include this workaround which will get the tests passing. There are other changes to the task definition which might cause breakages in other ways, so we'll need to monitor the next test run and see how it goes.

Note that the bundle being changed is over two months old:

    $ skopeo inspect --no-tags docker://quay.io/hacbs-contract/ec-task-bundle:cf58b68b872dacbbcb2cc571efac135b2989d638 | jq .Created
    "2023-05-11T09:52:31.718536249Z"

    $ skopeo inspect --no-tags docker://quay.io/hacbs-contract/ec-task-bundle:7f2e25e9fc6c64c95238628b0b2bdbd1aeb79454 | jq .Created
    "2023-03-02T14:15:07.232481899Z"

To see everything that changed we can look at the diff in the ec-cli repo, e.g.:
   git diff 7f2e25e cf58b68

There are a lot of changes actually, including changes to the steps and the step names.

JIRA: [RHTAPBUGS-254](https://issues.redhat.com/browse/RHTAPBUGS-254)