### PR TITLE
fix(RHTAPBUGS-254): Add version 0.11 ec task update

### DIFF
--- a/catalog/pipeline/release/0.11/README.md
+++ b/catalog/pipeline/release/0.11/README.md
@@ -1,0 +1,91 @@
+# Release Pipeline
+
+Tekton pipeline to release Stonesoup Snapshot to Quay.
+
+## Parameters
+
+| Name | Description | Optional | Default value |
+|------|-------------|----------|---------------|
+| snapshot | The Snapshot in JSON format | No | - |
+| enterpriseContractPolicy | JSON representation of the policy to be applied when validating the enterprise contract | No | - |
+| extraConfigGitUrl |URL to the remote Git repository containing the extra config | No | - |
+| extraConfigGitRevision | Revision to fetch from the remote Git repository containing the extra config | No | - |
+| extraConfigPath | Path to the extra config file within the repository | No | - |
+| addGitShaTag | When pushing the snapshot components, also push a tag with the image git sha | Yes | false |
+| postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
+
+## Changes since 0.10
+
+Update tag of ec-task-bundle task
+
+## Changes since 0.9
+
+* The syntax for `taskRef.bundle` and `pipelineRef.bundle` is deprecated,
+bundles resolver is used with new format.
+* Upgrade push-snapshot task for v0.6 parameter
+  * addGitShaTag parameter is now supported and passed as a pipeline parameter to the task with value false
+
+## Changes since 0.8
+
+Update tag of ec-task-bundle task
+
+## Changes since 0.7
+
+Pipeline name was changed:
+* metadata.name = `release`
+
+## Changes since 0.6
+
+Pipeline definition was changed:
+* Task `verify-enterprise-contract` now uses the param `STRICT: 1`
+
+## Changes since 0.5
+
+Pipeline definition was changed:
+* Taskref renamed from `verify-enterprise-contract-v2` to `verify-enterprise-contract`
+* Taskref `verify-enterprise-contract` points to new bundle location.
+
+## Changes since 0.4
+
+ Pipeline definition was changed:
+  * Task `apply-mapping` was replaced with `task-apply-mapping`
+  * Task `cleanup-workspace` was replaced with `task-cleanup-workspace`
+
+## Changes since 0.3 (milestone-8)
+
+ Pipeline definition was changed:
+  * Parameter `applicationSnapshot` was changed to `snapshot`
+  * Task `apply-mapping` was changed
+    * Task parameter `applicationSnapshot` value was changed
+      * old: $(params.applicationSnapshot)
+      * new: $(params.snapshot)
+  * Task `prepare-validation` was changed
+    * Task parameter `applicationSnapshot` value was changed
+      * old: $(params.applicationSnapshot)
+      * new: $(params.snapshot)
+  * Task `push-application-snapshot` was changed
+    * Task parameter `mappedApplicationSnapshot` value was changed
+      * old: $(params.mappedApplicationSnapshot)
+      * new: $(params.mappedSnapshot)
+
+## Changes since 0.2 (milestone-6)
+
+* Pipeline definition was changed:
+  * Parameter `policy` was changed to `enterpriseContractPolicy`
+  * Task `verify-enterprise-contract` was changed
+    * Task parameter `POLICY_CONFIGURATION` value was changed
+      * old: $(params.policy)
+      * new: $(params.enterpriseContractPolicy)
+
+## Changes since 0.1 (milestone-5)
+
+* Enterprise Contract task was changed:
+  * Task `prepare-validation` was removed
+  * Task `verify-enterprise-contract` was replaced
+    * old: quay.io/hacbs-release/verify-enterprise-contract:main
+    * new: quay.io/hacbs-release/verify-enterprise-contract-v2:main
+    * Task Parameter `snapshot` was removed
+    * Task parameter `IMAGES` was added
+    * Task Parameter `STRICT` was added
+    * Task Parameter `IMAGE_REF` was removed
+    * Task Parameter `REKOR_HOST` was removed

--- a/catalog/pipeline/release/0.11/release.yaml
+++ b/catalog/pipeline/release/0.11/release.yaml
@@ -1,0 +1,149 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: release
+  labels:
+    app.kubernetes.io/version: "0.11"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Tekton pipeline to release HACBS Snapshot to Quay
+  params:
+    - name: snapshot
+      type: string
+      description: The Snapshot in JSON format
+    - name: enterpriseContractPolicy
+      type: string
+      description: JSON representation of the EnterpriseContractPolicy
+    - name: extraConfigGitUrl
+      type: string
+      description: URL to the remote Git repository containing the extra config
+      default: ""
+    - name: extraConfigGitRevision
+      type: string
+      description: Revision to fetch from the remote Git repository containing the extra config
+      default: ""
+    - name: extraConfigPath
+      type: string
+      description: Path to the extra config file within the repository
+      default: ""
+    - name: addGitShaTag
+      type: string
+      description: When pushing the snapshot components, also push a tag with the image git sha
+      default: "false"
+    - name: postCleanUp
+      type: string
+      description: Cleans up workspace after finishing executing the pipeline
+      default: "true"
+  workspaces:
+    - name: release-workspace
+  tasks:
+    - name: clone-config-file
+      taskRef:
+        resolver: "bundles"
+        params:
+          - name: bundle
+            value: quay.io/redhat-appstudio/appstudio-tasks:583d33c8ddf0de2ea8e1a73d94a1ca4a6e6ed380-1
+          - name: kind
+            value: task
+          - name: name
+            value: git-clone
+      when:
+        - input: $(params.extraConfigGitUrl)
+          operator: notin
+          values: [""]
+      params:
+        - name: url
+          value: $(params.extraConfigGitUrl)
+        - name: revision
+          value: $(params.extraConfigGitRevision)
+        - name: subdirectory
+          value: "$(context.pipelineRun.uid)"
+      workspaces:
+        - name: output
+          workspace: release-workspace
+    - name: apply-mapping
+      taskRef:
+        resolver: "bundles"
+        params:
+          - name: bundle
+            value: quay.io/hacbs-release/task-apply-mapping:main
+          - name: kind
+            value: task
+          - name: name
+            value: apply-mapping
+      params:
+        - name: snapshot
+          value: $(params.snapshot)
+        - name: extraConfigPath
+          value: "$(context.pipelineRun.uid)/$(params.extraConfigPath)"
+      when:
+        - input: $(tasks.clone-config-file.results.commit)
+          operator: notin
+          values: [""]
+      workspaces:
+        - name: config
+          workspace: release-workspace
+    - name: verify-enterprise-contract
+      taskRef:
+        resolver: "bundles"
+        params:
+          - name: bundle
+            value: quay.io/hacbs-contract/ec-task-bundle:cf58b68b872dacbbcb2cc571efac135b2989d638
+          - name: kind
+            value: task
+          - name: name
+            value: verify-enterprise-contract
+      params:
+        - name: IMAGES
+          value: $(tasks.apply-mapping.results.snapshot)
+        - name: SSL_CERT_DIR
+          value: /var/run/secrets/kubernetes.io/serviceaccount
+        - name: POLICY_CONFIGURATION
+          value: $(params.enterpriseContractPolicy)
+        - name: STRICT
+          value: "1"
+    - name: push-snapshot
+      taskRef:
+        resolver: "bundles"
+        params:
+          - name: bundle
+            value: quay.io/hacbs-release/task-push-snapshot:main
+          - name: kind
+            value: task
+          - name: name
+            value: push-snapshot
+      params:
+        - name: mappedSnapshot
+          value: $(tasks.apply-mapping.results.snapshot)
+        - name: addGitShaTag
+          value: $(params.addGitShaTag)
+      runAfter:
+        - verify-enterprise-contract
+  finally:
+    - name: cleanup
+      taskRef:
+        resolver: "bundles"
+        params:
+          - name: bundle
+            value: quay.io/hacbs-release/task-cleanup-workspace:main
+          - name: kind
+            value: task
+          - name: name
+            value: cleanup-workspace
+      when:
+        - input: $(params.postCleanUp)
+          operator: in
+          values: ["true"]
+        - input: $(params.extraConfigGitUrl)
+          operator: notin
+          values: [""]
+      params:
+        - name: subdirectory
+          value: "$(context.pipelineRun.uid)"
+      workspaces:
+        - name: input
+          workspace: release-workspace

--- a/catalog/pipeline/release/0.11/samples/sample_release_PipelineRun.yaml
+++ b/catalog/pipeline/release/0.11/samples/sample_release_PipelineRun.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: release-run-empty-params
+spec:
+  params:
+    - name: snapshot
+      value: ""
+    - name: enterpriseContractPolicy
+      value: ""
+    - name: extraConfigGitUrl
+      value: ""
+    - name: extraConfigGitRevision
+      value: ""
+    - name: extraConfigPath
+      value: ""
+    - name: postCleanUp
+      value: ""
+  pipelineRef:
+    resolver: "bundles"
+    params:
+      - name: bundle
+        value: quay.io/hacbs-release/pipeline-release:0.11
+      - name: kind
+        value: pipeline
+      - name: name
+        value: release

--- a/catalog/pipeline/release/0.11/tests/run.yaml
+++ b/catalog/pipeline/release/0.11/tests/run.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: release-run-empty-params
+spec:
+  params:
+    - name: snapshot
+      value: ""
+    - name: enterpriseContractPolicy
+      value: ""
+    - name: extraConfigGitUrl
+      value: ""
+    - name: extraConfigGitRevision
+      value: ""
+    - name: extraConfigPath
+      value: ""
+    - name: postCleanUp
+      value: ""
+  pipelineRef:
+    resolver: "bundles"
+    params:
+      - name: bundle
+        value: quay.io/hacbs-release/pipeline-release:0.11
+      - name: kind
+        value: pipeline
+      - name: name
+        value: release


### PR DESCRIPTION
Bump the tag used in the ec task bundle the the latest.

The specific motivation for doing this now is this test failure:

    invalid uri: uri missing scheme prefix

The failure is related to this unmerged chains upstream PR: https://github.com/tektoncd/chains/pull/792 which has an ec workaround in https://github.com/enterprise-contract/ec-cli/pull/649 .

IIUC updating the task bundle should mean the version of ec used includes this workaround should get the tests passing.

There are other changes to the task definition which might cause breakages in other ways, so we'll need to monitor the next test run and see how it goes.

Note that there are over two months of changes since the last update. To see everything that changed we can look at the diff in the ec-cli repo, e.g. `git diff 7f2e25e cf58b68`. In particular there are changes to the steps and the step names.