### PR TITLE
feat(HACBS-2222): use new apply-mapping param in pipelines

### DIFF
--- a/catalog/pipeline/push-to-external-registry/0.9/README.md
+++ b/catalog/pipeline/push-to-external-registry/0.9/README.md
@@ -19,6 +19,10 @@ Tekton pipeline to push images to an external registry.
 | pyxisSecret | The kubernetes secret to use to authenticate to Pyxis. It needs to contain two keys: key and cert | No | - |
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 
+## Changes since 0.8
+* Use version 0.4 of apply-mapping task and set the new failOnEmptyResult parameter to true
+  * This will ensure that if the result of mapping is an empty component list, the task will fail
+
 ## Changes since 0.7
 * Upgrade push-snapshot task to version 0.7
   * Only the first 7 characters are used for the git sha tag in Quay.

--- a/catalog/pipeline/push-to-external-registry/0.9/README.md
+++ b/catalog/pipeline/push-to-external-registry/0.9/README.md
@@ -1,0 +1,53 @@
+# Push to External Registry Pipeline
+
+Tekton pipeline to push images to an external registry.
+
+## Parameters
+
+| Name | Description | Optional | Default value |
+|------|-------------|----------|---------------|
+| snapshot | The Snapshot in JSON format | No | - |
+| enterpriseContractPolicy | JSON representation of the policy to be applied when validating the enterprise contract | No | - |
+| extraConfigGitUrl |URL to the remote Git repository containing the extra config | No | - |
+| extraConfigGitRevision | Revision to fetch from the remote Git repository containing the extra config | No | - |
+| extraConfigPath | Path to the extra config file within the repository | No | - |
+| tag | The default tag to use when mapping file does not contain a tag | No | - |
+| addGitShaTag | When pushing the snapshot components, also push a tag with the image git sha | Yes | false |
+| addSourceShaTag | When pushing the snapshot components, also push a tag with the image source sha | Yes | true |
+| addTimestampTag | When pushing the snapshot components, also push a tag with the current timestamp | Yes | false |
+| pyxisServerType | The Pyxis server type to use. Options are 'production' and 'stage' | No | - |
+| pyxisSecret | The kubernetes secret to use to authenticate to Pyxis. It needs to contain two keys: key and cert | No | - |
+| postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
+
+## Changes since 0.7
+* Upgrade push-snapshot task to version 0.7
+  * Only the first 7 characters are used for the git sha tag in Quay.
+
+## Changes since 0.6
+Add `push-sbom-to-pyxis` task to the pipeline. This will ensure that sbom components
+for the image are pushed to Pyxis as part of this pipeline.
+
+## Changes since 0.5
+The syntax for `taskRef.bundle` and `pipelineRef.bundle` is deprecated,
+bundles resolver is used with new format.
+
+## Changes since 0.4
+* Upgrade push-snapshot task to version 0.6
+  * addShaTag parameter is now named addSourceShaTag
+  * addGitShaTag parameter is now supported and passed as a pipeline parameter to the task
+
+## Changes since 0.3
+
+* Upgrade push-snapshot task to version 0.5
+  * addShaTag parameter is now supported and passed as a pipeline parameter to the task
+  * addTimestampTag parameter is now supported and passed as a pipeline parameter to the task
+
+## Changes since 0.2
+
+* push-snapshot now supports tag parameter
+
+## Changes since 0.1
+
+* Upgrade create-pyxis-image task to version 0.2
+  * correct incorrect snapshot param
+

--- a/catalog/pipeline/push-to-external-registry/0.9/push-to-external-registry.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.9/push-to-external-registry.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: push-to-external-registry
   labels:
-    app.kubernetes.io/version: "0.8"
+    app.kubernetes.io/version: "0.9"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -88,7 +88,7 @@ spec:
         resolver: "bundles"
         params:
           - name: bundle
-            value: quay.io/hacbs-release/task-apply-mapping:0.3
+            value: quay.io/hacbs-release/task-apply-mapping:0.4
           - name: kind
             value: task
           - name: name
@@ -98,6 +98,8 @@ spec:
           value: $(params.snapshot)
         - name: extraConfigPath
           value: "$(context.pipelineRun.uid)/$(params.extraConfigPath)"
+        - name: failOnEmptyResult
+          value: "true"
       when:
         - input: $(tasks.clone-config-file.results.commit)
           operator: notin

--- a/catalog/pipeline/push-to-external-registry/0.9/push-to-external-registry.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.9/push-to-external-registry.yaml
@@ -1,0 +1,213 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: push-to-external-registry
+  labels:
+    app.kubernetes.io/version: "0.8"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Tekton pipeline to release HACBS Snapshot to Quay
+  params:
+    - name: snapshot
+      type: string
+      description: The Snapshot in JSON format
+    - name: enterpriseContractPolicy
+      type: string
+      description: JSON representation of the EnterpriseContractPolicy
+    - name: extraConfigGitUrl
+      type: string
+      description: URL to the remote Git repository containing the extra config
+      default: ""
+    - name: extraConfigGitRevision
+      type: string
+      description: Revision to fetch from the remote Git repository containing the extra config
+      default: ""
+    - name: extraConfigPath
+      type: string
+      description: Path to the extra config file within the repository
+      default: ""
+    - name: tag
+      type: string
+      description: The default tag to use when mapping file does not contain a tag
+    - name: addGitShaTag
+      type: string
+      description: When pushing the snapshot components, also push a tag with the image git sha
+      default: "false"
+    - name: addSourceShaTag
+      type: string
+      description: When pushing the snapshot components, also push a tag with the image source sha
+      default: "true"
+    - name: addTimestampTag
+      type: string
+      description: When pushing the snapshot components, also push a tag with the current timestamp
+      default: "false"
+    - name: pyxisServerType
+      type: string
+      description: The Pyxis server type to use. Options are 'production' and 'stage'
+    - name: pyxisSecret
+      type: string
+      description: |
+        The kubernetes secret to use to authenticate to Pyxis. It needs to contain two keys: key and cert
+    - name: postCleanUp
+      type: string
+      description: Cleans up workspace after finishing executing the pipeline
+      default: "true"
+  workspaces:
+    - name: release-workspace
+  tasks:
+    - name: clone-config-file
+      taskRef:
+        resolver: "bundles"
+        params:
+          - name: bundle
+            value: quay.io/redhat-appstudio/appstudio-tasks:583d33c8ddf0de2ea8e1a73d94a1ca4a6e6ed380-1
+          - name: kind
+            value: task
+          - name: name
+            value: git-clone
+      when:
+        - input: $(params.extraConfigGitUrl)
+          operator: notin
+          values: [""]
+      params:
+        - name: url
+          value: $(params.extraConfigGitUrl)
+        - name: revision
+          value: $(params.extraConfigGitRevision)
+        - name: subdirectory
+          value: "$(context.pipelineRun.uid)"
+      workspaces:
+        - name: output
+          workspace: release-workspace
+    - name: apply-mapping
+      taskRef:
+        resolver: "bundles"
+        params:
+          - name: bundle
+            value: quay.io/hacbs-release/task-apply-mapping:0.3
+          - name: kind
+            value: task
+          - name: name
+            value: apply-mapping
+      params:
+        - name: snapshot
+          value: $(params.snapshot)
+        - name: extraConfigPath
+          value: "$(context.pipelineRun.uid)/$(params.extraConfigPath)"
+      when:
+        - input: $(tasks.clone-config-file.results.commit)
+          operator: notin
+          values: [""]
+      workspaces:
+        - name: config
+          workspace: release-workspace
+    - name: verify-enterprise-contract
+      taskRef:
+        resolver: "bundles"
+        params:
+          - name: bundle
+            value: quay.io/hacbs-contract/ec-task-bundle:snapshot
+          - name: kind
+            value: task
+          - name: name
+            value: verify-enterprise-contract
+      params:
+        - name: IMAGES
+          value: $(tasks.apply-mapping.results.snapshot)
+        - name: SSL_CERT_DIR
+          value: /var/run/secrets/kubernetes.io/serviceaccount
+        - name: POLICY_CONFIGURATION
+          value: $(params.enterpriseContractPolicy)
+        - name: STRICT
+          value: "1"
+    - name: push-snapshot
+      taskRef:
+        resolver: "bundles"
+        params:
+          - name: bundle
+            value: quay.io/hacbs-release/task-push-snapshot:0.7
+          - name: kind
+            value: task
+          - name: name
+            value: push-snapshot
+      params:
+        - name: mappedSnapshot
+          value: $(tasks.apply-mapping.results.snapshot)
+        - name: tag
+          value: $(params.tag)
+        - name: addGitShaTag
+          value: $(params.addGitShaTag)
+        - name: addSourceShaTag
+          value: $(params.addSourceShaTag)
+        - name: addTimestampTag
+          value: $(params.addTimestampTag)
+      runAfter:
+        - verify-enterprise-contract
+    - name: create-pyxis-image
+      taskRef:
+        resolver: "bundles"
+        params:
+          - name: bundle
+            value: quay.io/hacbs-release/task-create-pyxis-image:0.3
+          - name: kind
+            value: task
+          - name: name
+            value: create-pyxis-image
+      params:
+        - name: server
+          value: $(params.pyxisServerType)
+        - name: pyxisSecret
+          value: $(params.pyxisSecret)
+        - name: tag
+          value: $(params.tag)
+        - name: mappedSnapshot
+          value: $(tasks.apply-mapping.results.snapshot)
+      runAfter:
+        - push-snapshot
+    - name: push-sbom-to-pyxis
+      taskRef:
+        resolver: "bundles"
+        params:
+          - name: bundle
+            value: quay.io/hacbs-release/task-push-sbom-to-pyxis:0.1
+          - name: kind
+            value: task
+          - name: name
+            value: push-sbom-to-pyxis
+      params:
+        - name: mappedSnapshot
+          value: $(tasks.apply-mapping.results.snapshot)
+        - name: containerImageIDs
+          value: $(tasks.create-pyxis-image.results.containerImageIDs)
+        - name: server
+          value: $(params.pyxisServerType)
+        - name: pyxisSecret
+          value: $(params.pyxisSecret)
+  finally:
+    - name: cleanup
+      taskRef:
+        resolver: "bundles"
+        params:
+          - name: bundle
+            value: quay.io/hacbs-release/task-cleanup-workspace:0.2
+          - name: kind
+            value: task
+          - name: name
+            value: cleanup-workspace
+      when:
+        - input: $(params.postCleanUp)
+          operator: in
+          values: ["true"]
+        - input: $(params.extraConfigGitUrl)
+          operator: notin
+          values: [""]
+      params:
+        - name: subdirectory
+          value: "$(context.pipelineRun.uid)"
+      workspaces:
+        - name: input
+          workspace: release-workspace

--- a/catalog/pipeline/push-to-external-registry/0.9/samples/sample_push-to-external-registry_PipelineRun.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.9/samples/sample_push-to-external-registry_PipelineRun.yaml
@@ -27,7 +27,7 @@ spec:
     resolver: "bundles"
     params:
       - name: bundle
-        value: quay.io/hacbs-release/pipeline-push-to-external-registry:0.8
+        value: quay.io/hacbs-release/pipeline-push-to-external-registry:0.9
       - name: kind
         value: pipeline
       - name: name

--- a/catalog/pipeline/push-to-external-registry/0.9/samples/sample_push-to-external-registry_PipelineRun.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.9/samples/sample_push-to-external-registry_PipelineRun.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: push-to-external-registry-run-empty-params
+spec:
+  params:
+    - name: snapshot
+      value: ""
+    - name: enterpriseContractPolicy
+      value: ""
+    - name: extraConfigGitUrl
+      value: ""
+    - name: extraConfigGitRevision
+      value: ""
+    - name: extraConfigPath
+      value: ""
+    - name: pyxisServerType
+      value: ""
+    - name: pyxisSecret
+      value: ""
+    - name: tag
+      value: ""
+    - name: postCleanUp
+      value: ""
+  pipelineRef:
+    resolver: "bundles"
+    params:
+      - name: bundle
+        value: quay.io/hacbs-release/pipeline-push-to-external-registry:0.8
+      - name: kind
+        value: pipeline
+      - name: name
+        value: push-to-external-registry

--- a/catalog/pipeline/push-to-external-registry/0.9/tests/run.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.9/tests/run.yaml
@@ -27,7 +27,7 @@ spec:
     resolver: "bundles"
     params:
       - name: bundle
-        value: quay.io/hacbs-release/pipeline-push-to-external-registry:0.8
+        value: quay.io/hacbs-release/pipeline-push-to-external-registry:0.9
       - name: kind
         value: pipeline
       - name: name

--- a/catalog/pipeline/push-to-external-registry/0.9/tests/run.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.9/tests/run.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: push-to-external-registry-run-empty-params
+spec:
+  params:
+    - name: snapshot
+      value: ""
+    - name: enterpriseContractPolicy
+      value: ""
+    - name: extraConfigGitUrl
+      value: ""
+    - name: extraConfigGitRevision
+      value: ""
+    - name: extraConfigPath
+      value: ""
+    - name: pyxisServerType
+      value: ""
+    - name: pyxisSecret
+      value: ""
+    - name: tag
+      value: ""
+    - name: postCleanUp
+      value: ""
+  pipelineRef:
+    resolver: "bundles"
+    params:
+      - name: bundle
+        value: quay.io/hacbs-release/pipeline-push-to-external-registry:0.8
+      - name: kind
+        value: pipeline
+      - name: name
+        value: push-to-external-registry

--- a/catalog/pipeline/release/0.12/README.md
+++ b/catalog/pipeline/release/0.12/README.md
@@ -1,0 +1,91 @@
+# Release Pipeline
+
+Tekton pipeline to release Stonesoup Snapshot to Quay.
+
+## Parameters
+
+| Name | Description | Optional | Default value |
+|------|-------------|----------|---------------|
+| snapshot | The Snapshot in JSON format | No | - |
+| enterpriseContractPolicy | JSON representation of the policy to be applied when validating the enterprise contract | No | - |
+| extraConfigGitUrl |URL to the remote Git repository containing the extra config | No | - |
+| extraConfigGitRevision | Revision to fetch from the remote Git repository containing the extra config | No | - |
+| extraConfigPath | Path to the extra config file within the repository | No | - |
+| addGitShaTag | When pushing the snapshot components, also push a tag with the image git sha | Yes | false |
+| postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
+
+## Changes since 0.10
+
+Update tag of ec-task-bundle task
+
+## Changes since 0.9
+
+* The syntax for `taskRef.bundle` and `pipelineRef.bundle` is deprecated,
+bundles resolver is used with new format.
+* Upgrade push-snapshot task for v0.6 parameter
+  * addGitShaTag parameter is now supported and passed as a pipeline parameter to the task with value false
+
+## Changes since 0.8
+
+Update tag of ec-task-bundle task
+
+## Changes since 0.7
+
+Pipeline name was changed:
+* metadata.name = `release`
+
+## Changes since 0.6
+
+Pipeline definition was changed:
+* Task `verify-enterprise-contract` now uses the param `STRICT: 1`
+
+## Changes since 0.5
+
+Pipeline definition was changed:
+* Taskref renamed from `verify-enterprise-contract-v2` to `verify-enterprise-contract`
+* Taskref `verify-enterprise-contract` points to new bundle location.
+
+## Changes since 0.4
+
+ Pipeline definition was changed:
+  * Task `apply-mapping` was replaced with `task-apply-mapping`
+  * Task `cleanup-workspace` was replaced with `task-cleanup-workspace`
+
+## Changes since 0.3 (milestone-8)
+
+ Pipeline definition was changed:
+  * Parameter `applicationSnapshot` was changed to `snapshot`
+  * Task `apply-mapping` was changed
+    * Task parameter `applicationSnapshot` value was changed
+      * old: $(params.applicationSnapshot)
+      * new: $(params.snapshot)
+  * Task `prepare-validation` was changed
+    * Task parameter `applicationSnapshot` value was changed
+      * old: $(params.applicationSnapshot)
+      * new: $(params.snapshot)
+  * Task `push-application-snapshot` was changed
+    * Task parameter `mappedApplicationSnapshot` value was changed
+      * old: $(params.mappedApplicationSnapshot)
+      * new: $(params.mappedSnapshot)
+
+## Changes since 0.2 (milestone-6)
+
+* Pipeline definition was changed:
+  * Parameter `policy` was changed to `enterpriseContractPolicy`
+  * Task `verify-enterprise-contract` was changed
+    * Task parameter `POLICY_CONFIGURATION` value was changed
+      * old: $(params.policy)
+      * new: $(params.enterpriseContractPolicy)
+
+## Changes since 0.1 (milestone-5)
+
+* Enterprise Contract task was changed:
+  * Task `prepare-validation` was removed
+  * Task `verify-enterprise-contract` was replaced
+    * old: quay.io/hacbs-release/verify-enterprise-contract:main
+    * new: quay.io/hacbs-release/verify-enterprise-contract-v2:main
+    * Task Parameter `snapshot` was removed
+    * Task parameter `IMAGES` was added
+    * Task Parameter `STRICT` was added
+    * Task Parameter `IMAGE_REF` was removed
+    * Task Parameter `REKOR_HOST` was removed

--- a/catalog/pipeline/release/0.12/README.md
+++ b/catalog/pipeline/release/0.12/README.md
@@ -14,6 +14,10 @@ Tekton pipeline to release Stonesoup Snapshot to Quay.
 | addGitShaTag | When pushing the snapshot components, also push a tag with the image git sha | Yes | false |
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 
+## Changes since 0.11
+* Use version 0.4 of apply-mapping task and set the new failOnEmptyResult parameter to true
+  * This will ensure that if the result of mapping is an empty component list, the task will fail
+
 ## Changes since 0.10
 
 Update tag of ec-task-bundle task

--- a/catalog/pipeline/release/0.12/release.yaml
+++ b/catalog/pipeline/release/0.12/release.yaml
@@ -1,0 +1,149 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: release
+  labels:
+    app.kubernetes.io/version: "0.11"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Tekton pipeline to release HACBS Snapshot to Quay
+  params:
+    - name: snapshot
+      type: string
+      description: The Snapshot in JSON format
+    - name: enterpriseContractPolicy
+      type: string
+      description: JSON representation of the EnterpriseContractPolicy
+    - name: extraConfigGitUrl
+      type: string
+      description: URL to the remote Git repository containing the extra config
+      default: ""
+    - name: extraConfigGitRevision
+      type: string
+      description: Revision to fetch from the remote Git repository containing the extra config
+      default: ""
+    - name: extraConfigPath
+      type: string
+      description: Path to the extra config file within the repository
+      default: ""
+    - name: addGitShaTag
+      type: string
+      description: When pushing the snapshot components, also push a tag with the image git sha
+      default: "false"
+    - name: postCleanUp
+      type: string
+      description: Cleans up workspace after finishing executing the pipeline
+      default: "true"
+  workspaces:
+    - name: release-workspace
+  tasks:
+    - name: clone-config-file
+      taskRef:
+        resolver: "bundles"
+        params:
+          - name: bundle
+            value: quay.io/redhat-appstudio/appstudio-tasks:583d33c8ddf0de2ea8e1a73d94a1ca4a6e6ed380-1
+          - name: kind
+            value: task
+          - name: name
+            value: git-clone
+      when:
+        - input: $(params.extraConfigGitUrl)
+          operator: notin
+          values: [""]
+      params:
+        - name: url
+          value: $(params.extraConfigGitUrl)
+        - name: revision
+          value: $(params.extraConfigGitRevision)
+        - name: subdirectory
+          value: "$(context.pipelineRun.uid)"
+      workspaces:
+        - name: output
+          workspace: release-workspace
+    - name: apply-mapping
+      taskRef:
+        resolver: "bundles"
+        params:
+          - name: bundle
+            value: quay.io/hacbs-release/task-apply-mapping:main
+          - name: kind
+            value: task
+          - name: name
+            value: apply-mapping
+      params:
+        - name: snapshot
+          value: $(params.snapshot)
+        - name: extraConfigPath
+          value: "$(context.pipelineRun.uid)/$(params.extraConfigPath)"
+      when:
+        - input: $(tasks.clone-config-file.results.commit)
+          operator: notin
+          values: [""]
+      workspaces:
+        - name: config
+          workspace: release-workspace
+    - name: verify-enterprise-contract
+      taskRef:
+        resolver: "bundles"
+        params:
+          - name: bundle
+            value: quay.io/hacbs-contract/ec-task-bundle:cf58b68b872dacbbcb2cc571efac135b2989d638
+          - name: kind
+            value: task
+          - name: name
+            value: verify-enterprise-contract
+      params:
+        - name: IMAGES
+          value: $(tasks.apply-mapping.results.snapshot)
+        - name: SSL_CERT_DIR
+          value: /var/run/secrets/kubernetes.io/serviceaccount
+        - name: POLICY_CONFIGURATION
+          value: $(params.enterpriseContractPolicy)
+        - name: STRICT
+          value: "1"
+    - name: push-snapshot
+      taskRef:
+        resolver: "bundles"
+        params:
+          - name: bundle
+            value: quay.io/hacbs-release/task-push-snapshot:main
+          - name: kind
+            value: task
+          - name: name
+            value: push-snapshot
+      params:
+        - name: mappedSnapshot
+          value: $(tasks.apply-mapping.results.snapshot)
+        - name: addGitShaTag
+          value: $(params.addGitShaTag)
+      runAfter:
+        - verify-enterprise-contract
+  finally:
+    - name: cleanup
+      taskRef:
+        resolver: "bundles"
+        params:
+          - name: bundle
+            value: quay.io/hacbs-release/task-cleanup-workspace:main
+          - name: kind
+            value: task
+          - name: name
+            value: cleanup-workspace
+      when:
+        - input: $(params.postCleanUp)
+          operator: in
+          values: ["true"]
+        - input: $(params.extraConfigGitUrl)
+          operator: notin
+          values: [""]
+      params:
+        - name: subdirectory
+          value: "$(context.pipelineRun.uid)"
+      workspaces:
+        - name: input
+          workspace: release-workspace

--- a/catalog/pipeline/release/0.12/release.yaml
+++ b/catalog/pipeline/release/0.12/release.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: release
   labels:
-    app.kubernetes.io/version: "0.11"
+    app.kubernetes.io/version: "0.12"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -70,7 +70,7 @@ spec:
         resolver: "bundles"
         params:
           - name: bundle
-            value: quay.io/hacbs-release/task-apply-mapping:main
+            value: quay.io/hacbs-release/task-apply-mapping:0.4
           - name: kind
             value: task
           - name: name
@@ -80,6 +80,8 @@ spec:
           value: $(params.snapshot)
         - name: extraConfigPath
           value: "$(context.pipelineRun.uid)/$(params.extraConfigPath)"
+        - name: failOnEmptyResult
+          value: "true"
       when:
         - input: $(tasks.clone-config-file.results.commit)
           operator: notin

--- a/catalog/pipeline/release/0.12/samples/sample_release_PipelineRun.yaml
+++ b/catalog/pipeline/release/0.12/samples/sample_release_PipelineRun.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: release-run-empty-params
+spec:
+  params:
+    - name: snapshot
+      value: ""
+    - name: enterpriseContractPolicy
+      value: ""
+    - name: extraConfigGitUrl
+      value: ""
+    - name: extraConfigGitRevision
+      value: ""
+    - name: extraConfigPath
+      value: ""
+    - name: postCleanUp
+      value: ""
+  pipelineRef:
+    resolver: "bundles"
+    params:
+      - name: bundle
+        value: quay.io/hacbs-release/pipeline-release:0.11
+      - name: kind
+        value: pipeline
+      - name: name
+        value: release

--- a/catalog/pipeline/release/0.12/samples/sample_release_PipelineRun.yaml
+++ b/catalog/pipeline/release/0.12/samples/sample_release_PipelineRun.yaml
@@ -21,7 +21,7 @@ spec:
     resolver: "bundles"
     params:
       - name: bundle
-        value: quay.io/hacbs-release/pipeline-release:0.11
+        value: quay.io/hacbs-release/pipeline-release:0.12
       - name: kind
         value: pipeline
       - name: name

--- a/catalog/pipeline/release/0.12/tests/run.yaml
+++ b/catalog/pipeline/release/0.12/tests/run.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: release-run-empty-params
+spec:
+  params:
+    - name: snapshot
+      value: ""
+    - name: enterpriseContractPolicy
+      value: ""
+    - name: extraConfigGitUrl
+      value: ""
+    - name: extraConfigGitRevision
+      value: ""
+    - name: extraConfigPath
+      value: ""
+    - name: postCleanUp
+      value: ""
+  pipelineRef:
+    resolver: "bundles"
+    params:
+      - name: bundle
+        value: quay.io/hacbs-release/pipeline-release:0.11
+      - name: kind
+        value: pipeline
+      - name: name
+        value: release

--- a/catalog/pipeline/release/0.12/tests/run.yaml
+++ b/catalog/pipeline/release/0.12/tests/run.yaml
@@ -21,7 +21,7 @@ spec:
     resolver: "bundles"
     params:
       - name: bundle
-        value: quay.io/hacbs-release/pipeline-release:0.11
+        value: quay.io/hacbs-release/pipeline-release:0.12
       - name: kind
         value: pipeline
       - name: name


### PR DESCRIPTION
This adds new versions of the release and push-to-external-registry
pipelines that will use the new version of apply-mapping task
along with the failOnEmptyResult parameter set to "true".

As a consequence, if the resulting snaphot from apply-mapping
contains an empty list of components, the task will fail.

Signed-off-by: Martin Malina <mmalina@redhat.com>