### PR TITLE
feat(HACBS-2207): Production IIB pipeline only overwrites fromImage and copies to targetImage when opted-in

### DIFF
--- a/catalog/pipeline/fbc-release/0.12/README.md
+++ b/catalog/pipeline/fbc-release/0.12/README.md
@@ -1,0 +1,83 @@
+# FBC Release Pipeline
+
+Tekton release pipeline to interact with FBC Pipeline
+
+## Parameters
+
+| Name | Description | Optional | Default value |
+|------|-------------|----------|---------------|
+| snapshot | The Snapshot in JSON format | No | - |
+| enterpriseContractPolicy | JSON representation of the EnterpriseContractPolicy | No | - |
+| fromIndex | The source Index image (catalog of catalogs) FBC fragment | No | - |
+| targetIndex | Index image (catalog of catalogs) the FBC fragment will be added to | No | - |
+| binaryImage | OCP binary image to be baked into the index image | Yes | "" |
+| buildTags | List of additional tags the internal index image copy should be tagged with | Yes | "[]" |
+| addArches | List of arches the index image should be built for | Yes | "[]" |
+| requester | Name of the user that requested the signing, for auditing purposes | No | - |
+| signingConfigMapName | The ConfigMap to be used by the signing Pipeline | Yes | "hacbs-signing-pipeline-config" |
+| requestUpdateTimeout | Max seconds to wait until the status is updated | Yes | - |
+| buildTimeoutSeconds | Max seconds to wait until the build finishes | Yes | - |
+| verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
+
+## Changelog
+
+### Changes since 0.11
+- updates tasks that use `create-internal-request` task to 0.6 as now they need to
+  rely on its `genericResult` result
+- the task `publish-index-image` now uses `create-internal-request` so the publishing
+  is done by the cluster running the internal-services-controller
+- only executes `publish-index-image` and `sign-index-image` when genericResult result of
+  the tasks using `create-internal-request` has `fbc_opt_in=true` value set
+- removes `fbcPublishingCredentials` parameter
+- removes `overwriteFromIndex` parameter
+
+### Changes since 0.10
+- the verify_ec_task_bundle parameter was added
+    - with this addition, the verify-enterprise-contract task version is no longer static
+
+### Changes since 0.9
+- changes on the following tasks due to `create-internal-request` changes:
+    - `add-fbc-contribution-to-index-image` now accepts dynamic parameters
+    - `sign-index-image` now accepts dynamic parameters
+- changes on `publish-index-image` task to read data from its `inputDataFile` parameter
+- adds cleanup task
+
+### Changes since 0.8
+- fixes in the README.md file
+- adds param `fbcPublishingCredentials`
+- removes param `overwriteFromIndex`
+- adds new task `publish-index-image`
+
+### Changes since 0.7
+The syntax for `taskRef.bundle` and `pipelineRef.bundle` is deprecated,
+bundles resolver is used with new format.
+
+### Changes since 0.6
+- adds sign-index-image task
+- refactor task and change its reference name from `create-internal-request`
+  to `add-fbc-contribution-to-index-image`
+- adds `requester` and `signingConfigMapName` parameters
+- removes `resolvedIndexImage` result
+
+### Changes since 0.5
+- updates `create-internal-request` task version to 0.3
+
+### Changes since 0.4
+- updates `create-internal-request` task version to 0.2
+- adds `resolvedIndexImage` result
+
+### Changes since 0.3
+- removes param `fbcFragment`
+- adds param `buildTimeoutSeconds`
+
+### Changes since 0.2
+- renames the pipeline to `fbc-release`
+- forces the pipeline to run after `verify-enterprise-contract`
+
+### Changes since 0.1
+- adds param `requestUpdateTimeout`
+- adds task result values to the pipeline results
+  - `requestMessage` gets `$(tasks.create-internal-request.results.requestMessage)`
+  - `requestReason` gets `$(tasks.create-internal-request.results.requestReason)`
+  - `requestResults` gets `$(tasks.create-internal-request.results.requestResults)`
+- changes `verify-enterprise-contract` task version

--- a/catalog/pipeline/fbc-release/0.12/fbc-release.yaml
+++ b/catalog/pipeline/fbc-release/0.12/fbc-release.yaml
@@ -1,0 +1,207 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: fbc-release
+  labels:
+    app.kubernetes.io/version: "0.12"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Tekton release pipeline to interact with FBC Pipeline
+  params:
+    - name: snapshot
+      type: string
+      description: The Snapshot in JSON format
+    - name: enterpriseContractPolicy
+      type: string
+      description: JSON representation of the EnterpriseContractPolicy
+    - name: fromIndex
+      type: string
+      description: The source Index image (catalog of catalogs) FBC fragment
+    - name: targetIndex
+      type: string
+      description: Index image (catalog of catalogs) the FBC fragment will be added to
+    - name: binaryImage
+      type: string
+      default: ""
+      description: OCP binary image to be baked into the index image
+    - name: buildTags
+      type: string
+      default: "[]"
+      description: List of additional tags the internal index image copy should be tagged with
+    - name: addArches
+      type: string
+      default: "[]"
+      description: List of arches the index image should be built for
+    - name: requester
+      type: string
+      description: Name of the user that requested the signing, for auditing purposes
+    - name: signingConfigMapName
+      type: string
+      default: "hacbs-signing-pipeline-config"
+      description: The ConfigMap to be used by the signing Pipeline
+    - name: requestUpdateTimeout
+      type: string
+      description: Max seconds to wait until the status is updated
+    - name: buildTimeoutSeconds
+      type: string
+      description: Max seconds to wait until the build finishes
+    - name: verify_ec_task_bundle
+      type: string
+      description: The location of the bundle containing the verify-enterprise-contract task
+  workspaces:
+    - name: release-workspace
+  results:
+    - name: requestMessage
+      value: $(tasks.add-fbc-contribution-to-index-image.results.requestMessage)
+    - name: requestReason
+      value: $(tasks.add-fbc-contribution-to-index-image.results.requestReason)
+  tasks:
+    - name: verify-enterprise-contract
+      taskRef:
+        resolver: "bundles"
+        params:
+          - name: bundle
+            value: $(params.verify_ec_task_bundle)
+          - name: kind
+            value: task
+          - name: name
+            value: verify-enterprise-contract
+      params:
+        - name: IMAGES
+          value: $(params.snapshot)
+        - name: SSL_CERT_DIR
+          value: /var/run/secrets/kubernetes.io/serviceaccount
+        - name: POLICY_CONFIGURATION
+          value: $(params.enterpriseContractPolicy)
+        - name: STRICT
+          value: "1"
+    - name: add-fbc-contribution-to-index-image
+      workspaces:
+        - name: input
+          workspace: release-workspace
+      taskRef:
+        resolver: "bundles"
+        params:
+          - name: bundle
+            value: quay.io/hacbs-release/task-create-internal-request:0.6
+          - name: kind
+            value: task
+          - name: name
+            value: create-internal-request
+      params:
+        - name: pipelineRunName
+          value: $(context.pipelineRun.name)
+        - name: request
+          value: "iib"
+        - name: updateGenericResult
+          value: "true"
+        - name: params
+          value:
+            - name: binaryImage
+              value: "$(params.binaryImage)"
+            - name: fromIndex
+              value: "$(params.fromIndex)"
+            - name: buildTags
+              value: "$(params.buildTags)"
+            - name: addArches
+              value: "$(params.addArches)"
+            - name: buildTimeoutSeconds
+              value: "$(params.buildTimeoutSeconds)"
+            - name: fbcFragment
+              value: '$(params.snapshot)'
+              jsonKey: ".components[0].containerImage"
+      runAfter:
+        - verify-enterprise-contract
+    - name: sign-index-image
+      workspaces:
+        - name: input
+          workspace: release-workspace
+      taskRef:
+        resolver: "bundles"
+        params:
+          - name: bundle
+            value: quay.io/hacbs-release/task-create-internal-request:0.6
+          - name: kind
+            value: task
+          - name: name
+            value: create-internal-request
+      params:
+        - name: pipelineRunName
+          value: $(context.pipelineRun.name)
+        - name: inputDataFile
+          value: $(tasks.add-fbc-contribution-to-index-image.results.requestResultsFile)
+        - name: request
+          value: "hacbs-signing-pipeline"
+        - name: params
+          value:
+            - name: manifest_digest
+              value: "sharedRequestFile:json:.jsonBuildInfo"
+              jsonKey: ".index_image_resolved"
+            - name: pipeline_image
+              value: "quay.io/redhat-isv/operator-pipelines-images:released"
+            - name: reference
+              value: $(params.targetIndex)
+            - name: requester
+              value: $(params.requester)
+            - name: config_map_name
+              value: $(params.signingConfigMapName)
+      when:
+        - input: "$(tasks.add-fbc-contribution-to-index-image.results.genericResult)"
+          operator: in
+          values: ["fbc_opt_in=true"]
+    - name: publish-index-image
+      workspaces:
+        - name: input
+          workspace: release-workspace
+      taskRef:
+        resolver: "bundles"
+        params:
+          - name: bundle
+            value: quay.io/hacbs-release/task-create-internal-request:0.6
+          - name: kind
+            value: task
+          - name: name
+            value: create-internal-request
+      params:
+        - name: pipelineRunName
+          value: $(context.pipelineRun.name)
+        - name: inputDataFile
+          value: $(tasks.add-fbc-contribution-to-index-image.results.requestResultsFile)
+        - name: request
+          value: "publish-index-image-pipeline"
+        - name: params
+          value:
+            - name: sourceIndex
+              value: "sharedRequestFile:json:.jsonBuildInfo"
+              jsonKey: ".index_image_resolved"
+            - name: targetIndex
+              value: $(params.targetIndex)
+            - name: retries
+              value: "0"
+      when:
+        - input: "$(tasks.add-fbc-contribution-to-index-image.results.genericResult)"
+          operator: in
+          values: ["fbc_opt_in=true"]
+      runAfter:
+        - sign-index-image
+  finally:
+    - name: cleanup
+      taskRef:
+        resolver: "bundles"
+        params:
+          - name: bundle
+            value: quay.io/hacbs-release/task-cleanup-workspace:main
+          - name: kind
+            value: task
+          - name: name
+            value: cleanup-workspace
+      params:
+        - name: subdirectory
+          value: "internal-request"
+      workspaces:
+        - name: input
+          workspace: release-workspace

--- a/catalog/pipeline/fbc-release/0.12/samples/sample_release_PipelineRun.yaml
+++ b/catalog/pipeline/fbc-release/0.12/samples/sample_release_PipelineRun.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: fbc-release-run-empty-params
+spec:
+  params:
+    - name: snapshot
+      value: ""
+    - name: enterpriseContractPolicy
+      value: ""
+    - name: fromIndex
+      value: ""
+    - name: targetIndex
+      value: ""
+    - name: binaryImage
+      value: ""
+    - name: buildTags
+      value: ""
+    - name: addArches
+      value: ""
+    - name: requester
+      value: ""
+    - name: signingConfigMapName
+      value: ""
+    - name: requestUpdateTimeout
+      value: ""
+    - name: buildTimeoutSeconds
+      value: ""
+    - name: verify_ec_task_bundle
+      value: ""
+  pipelineRef:
+    resolver: "bundles"
+    params:
+      - name: bundle
+        value: quay.io/hacbs-release/pipeline-fbc-release:0.12
+      - name: kind
+        value: pipeline
+      - name: name
+        value: fbc-release

--- a/catalog/pipeline/fbc-release/0.12/tests/run.yaml
+++ b/catalog/pipeline/fbc-release/0.12/tests/run.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: fbc-release-run-empty-params
+spec:
+  params:
+    - name: snapshot
+      value: ""
+    - name: enterpriseContractPolicy
+      value: ""
+    - name: fromIndex
+      value: ""
+    - name: targetIndex
+      value: ""
+    - name: binaryImage
+      value: ""
+    - name: buildTags
+      value: ""
+    - name: addArches
+      value: ""
+    - name: requester
+      value: ""
+    - name: signingConfigMapName
+      value: ""
+    - name: requestUpdateTimeout
+      value: ""
+    - name: buildTimeoutSeconds
+      value: ""
+    - name: verify_ec_task_bundle
+      value: ""
+  pipelineRef:
+    resolver: "bundles"
+    params: 
+      - name: bundle
+        value: quay.io/hacbs-release/pipeline-fbc-release:0.12
+      - name: kind
+        value: pipeline
+      - name: name
+        value: fbc-release

--- a/catalog/task/create-internal-request/0.6/README.md
+++ b/catalog/task/create-internal-request/0.6/README.md
@@ -1,0 +1,38 @@
+# create-internal-request
+
+Creates an InternalRequest resource to call IIB service
+
+## Parameters
+
+| Name | Description | Optional | Default value |
+|------|-------------|----------|---------------|
+| pipelineRunName | The name of the Parent PipelineRun for this task | No | `ir-$(context.pipelineRun.name)` |
+| request | Internal pipeline request name | No | |
+| params | Internal Request parameters | No | |
+| inputDataFile | Optional file to read data from | Yes | "" |
+| updateGenericResult | Should the task update the genericResult result  | Yes | "false" |
+| requestUpdateTimeout | Max seconds to wait until the status is updated | Yes | 360 |
+
+## Changelog
+
+### changes since 0.5
+- adds `updateGenericResult` parameter to control whether the `genericResult`
+  result is updated
+- adds `genericResult` to store data read from the `genericResult` status message
+  from an `InternalRequest`
+- updates `release-base-image` image to latest version
+
+### changes since 0.4
+- full rewrite to accept dynamic parameters
+
+### changes since 0.3
+- removes the additional logging
+- removes `resolvedIndexImage` and `resolvedFromIndexImage` results
+  as now the FBC-Release Pipeline uses `requestResults` to read required values.
+
+### changes since 0.2
+- adds additional logging messages
+
+### changes since 0.1
+- adds `resolvedIndexImage` result
+- adds params `requestUpdateTimeout` and `buildTimeoutSeconds`

--- a/catalog/task/create-internal-request/0.6/create-internal-request.yaml
+++ b/catalog/task/create-internal-request/0.6/create-internal-request.yaml
@@ -1,0 +1,182 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: create-internal-request
+  labels:
+    app.kubernetes.io/version: "0.6"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+      Creates an InternalRequest resource to call IIB service
+  params:
+    - name: pipelineRunName
+      type: string
+      description: The name of the Parent PipelineRun of this task
+    - name: request
+      type: string
+      description: request type
+    - name: params
+      type: string
+      description: Internal Request parameters
+    - name: inputDataFile
+      type: string
+      description: Optional file to read data from
+      default: ""
+    - name: updateGenericResult
+      default: "false"
+      description: Should the task update the genericResult result
+    - name: requestUpdateTimeout
+      type: string
+      default: "360"
+      description: Max seconds waiting for the status update
+  results:
+    - name: requestMessage
+      description: Internal Request message
+    - name: requestReason
+      description: Internal Request reason
+    - name: requestResultsFile
+      description: Internal Request results file
+    - name: genericResult
+      description: genericResult field from the InternalRequest Status to expose to the PipelineRun
+  workspaces:
+    - name: input
+      description: Workspace to store the params and responses for the internalRequest
+  steps:
+    - name: prepare-internal-request
+      image:
+        quay.io/hacbs-release/release-base-image@sha256:5968660e005b0c806dd2568b6c8b488b4b519ed33daa41211b9f9f2bde4faf35
+      script: |
+          #!/usr/bin/env bash
+          #
+          set -e
+          # Tekton wraps the $(param.params) in a JSON string that in some usecases might contain another JSON string
+          # that breaks jq parsing, so we need to sanitize it before parsing it. Currently it supports only single
+          # nested JSON string.
+
+          # sanitize
+          #
+          # param string `file`
+          sanitize() {
+            TEMP="${1}-tmp"
+            # UNESCAPED=$(grep -Po  "(?<=.sanitize.)(.*)+(?=./sanitize.)" ${1})
+            SANITIZED_JSON=$(awk -e \
+                '{match($0, /"{.*}"/, m); 
+                {start=index($0, m[0])+1; end=length(m[0])-2} print substr($0, start, end) }' ${1} | \
+                jq -Rc "." | sed 's|\\|\\\\|g')
+            awk -v sanitized=${SANITIZED_JSON} -e '{gsub(/"{.*}"/, sanitized); gsub("\\\\","\\\\\\"); print}' ${1} \
+            | tee ${TEMP}
+
+            if jq "." ${TEMP} >/dev/null; then
+              mv ${TEMP} ${1}
+            else
+                return 1
+            fi
+          }
+
+          # saving the parameters preserving the string as is
+          JSON_PARAMS="/tmp/json-params-$$.txt"
+          cat > ${JSON_PARAMS} <<JSON
+          $(params.params)
+          JSON
+
+          # sanitizing the string
+          sanitize ${JSON_PARAMS}
+
+          # building the InternalRequest yaml
+          #
+          IR_DIR="$(workspaces.input.path)/internal-request"
+          [ -d "${IR_DIR}" ] || mkdir ${IR_DIR}
+          IR="${IR_DIR}/ir-$(params.pipelineRunName)-$(context.taskRun.uid).yaml"
+          cat > ${IR} <<YAML
+          apiVersion: appstudio.redhat.com/v1alpha1
+          kind: InternalRequest
+          metadata:
+            name: "ir-$(params.pipelineRunName)-$(params.request)"
+          spec:
+            request: "$(params.request)"
+            params:
+          YAML
+
+          LENGTH=`jq ". | length" ${JSON_PARAMS}`
+          for (( i=0; i<${LENGTH}; i++ )); do
+            INPUT=$(jq -r ".[${i}]|[.name, .value]| @tsv" ${JSON_PARAMS})
+            read -r PARAM VALUE <<< "${INPUT}"
+            if [ `jq -e ".[${i}]| has(\"jsonKey\")" ${JSON_PARAMS}` == "true" ]; then
+                JSON_KEY=`jq -r ".[${i}]|[.jsonKey]| @tsv" ${JSON_PARAMS}`
+                # check if the request needs the sharedRequestFile;
+                # otherwise the source is a json string
+                IFS=":" read -r SOURCE TYPE KEY  <<< $VALUE
+                if [ "${SOURCE}" == "sharedRequestFile" ]; then
+                    case ${TYPE} in
+                        "json")
+                            # it has a nested json string
+                            VALUE=`jq -cr "${KEY}" $(params.inputDataFile) \
+                            | jq -cr "${JSON_KEY}"`
+                        ;;
+                    esac
+                else
+                    VALUE=$(echo "${VALUE}" |tr -d "\\" 2>/dev/null |tr -d "\'" |jq -cr "${JSON_KEY}")
+                fi
+            fi
+            echo "    ${PARAM}: \"${VALUE}\"" >> ${IR}
+          done
+    - name: create-internal-request
+      image: 
+        quay.io/hacbs-release/release-base-image@sha256:5968660e005b0c806dd2568b6c8b488b4b519ed33daa41211b9f9f2bde4faf35
+      script: |
+          #!/usr/bin/env sh
+          PATH=/bin:/usr/bin:/usr/local/bin
+          export PATH
+
+          IR_DIR="$(workspaces.input.path)/internal-request"
+          IR="${IR_DIR}/ir-$(params.pipelineRunName)-$(context.taskRun.uid).yaml"
+          kubectl create -f ${IR}
+    - name: watch-internal-request-status
+      image:
+        quay.io/hacbs-release/release-base-image@sha256:5968660e005b0c806dd2568b6c8b488b4b519ed33daa41211b9f9f2bde4faf35
+      script: |
+          #!/usr/bin/env sh
+          PATH=/bin:/usr/bin:/usr/local/bin
+          TASKRUN="/tmp/$$.sh"
+
+          cat > ${TASKRUN} <<SH
+          #!/usr/bin/env sh
+          #
+          # the task might need to get input from a shared file
+          IR_DIR="$(workspaces.input.path)/internal-request"
+          RESULTSFILE="\${IR_DIR}/$(params.pipelineRunName)-$(context.taskRun.uid)-results.txt"
+          echo -n \${RESULTSFILE} |tee $(results.requestResultsFile.path)
+
+          IR="ir-$(params.pipelineRunName)-$(params.request)"
+          while true; do
+            STATUS=\$(kubectl get internalrequest \${IR} -o jsonpath='{.status.conditions[0].status}')
+            case "\${STATUS}" in
+              True | False )
+                echo "InternalRequest finished"
+                kubectl get internalrequest \${IR} -o jsonpath='{.status.conditions[0].reason}' \
+                | tee $(results.requestReason.path)
+                kubectl get internalrequest \${IR} -o jsonpath='{.status.conditions[0].message}' \
+                | tee $(results.requestMessage.path)
+                if [ "$(params.updateGenericResult)" == "true" ]; then
+                    kubectl get internalrequest \${IR} -o jsonpath='{.status.results.genericResult}' \
+                    | tee $(results.genericResult.path)
+                fi
+                kubectl get internalrequest \${IR} -o jsonpath='{.status.results}' \
+                | tee \${RESULTSFILE}
+                break
+                ;;
+              "*")
+                ;;
+            esac
+            sleep 30
+          done
+          [ \$(kubectl get internalrequest \${IR} -o jsonpath='{.status.conditions[0].status}') == "True" ]
+          SH
+          chmod +x ${TASKRUN}
+          timeout $(params.requestUpdateTimeout) ${TASKRUN}
+          SYSEXIT=$?
+          [ ${SYSEXIT} -eq 124 ] && echo "Timeout while waiting for the internal request update"
+          exit ${SYSEXIT}

--- a/catalog/task/create-internal-request/0.6/samples/sample_create-internal-request_TaskRun.yaml
+++ b/catalog/task/create-internal-request/0.6/samples/sample_create-internal-request_TaskRun.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: create-internal-request-run-empty-params
+spec:
+  params:
+    - name: pipelineRunName
+      value: ""
+    - name: request
+      value: ""
+    - name: params
+      value: ""
+    - name: inputDataFile
+      value: ""
+  taskRef:
+    name: create-internal-request
+    bundle: quay.io/hacbs-release/task-create-internal-request:0.6

--- a/catalog/task/create-internal-request/0.6/tests/run.yaml
+++ b/catalog/task/create-internal-request/0.6/tests/run.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: create-internal-request-run-empty-params
+spec:
+  params:
+    - name: pipelineRunName
+      value: ""
+    - name: request
+      value: ""
+    - name: params
+      value: ""
+    - name: inputDataFile
+      value: ""
+  taskRef:
+    name: create-internal-request
+    bundle: quay.io/hacbs-release/task-create-internal-request:0.6


### PR DESCRIPTION
feat(HACBS-2207): fbc-release must overwrite fromIndex for opt-in images

- updates fbc-release to 0.12
  - removes overwriteFromIndex parameter
  - updates pipeline to use create-internal-request version 0.6
  - changes publish-index-image to use create-internal-request so the
    publishing can be done throught the internal cluster
  - only publishes FBC indexes when the fragment is opt-in

- updates task create-internal-request to 0.6
  - updates `release-base-image` to the latest version

Signed-off-by: Leandro Mendes <lmendes@redhat.com>