### PR TITLE
fix: wrong files pattern for task tests workflow

### DIFF
--- a/.github/workflows/tekton_task_tests.yaml
+++ b/.github/workflows/tekton_task_tests.yaml
@@ -44,7 +44,7 @@ jobs:
         uses: tj-actions/changed-files@v35
         with:
           files: |
-            catalog/task/*/*
+            catalog/task/*/*/*
           dir_names: "true"
           dir_names_max_depth: "4"
       - name: Show changed dirs


### PR DESCRIPTION
The workflow is supposed to pick up versioned task dirs
(the directories that contain the task definitions)
that were changed and to run tests for each of them.

Before this fix, it could also pick up a directory one
level up. E.g. if catalog/task/kubernetes-actions/OWNERS
was changed, it would include catalog/task/kubernetes-actions
in the list of changed directories.

For reference, this issue was spotted in Johnny's PR here: https://github.com/redhat-appstudio/release-service-bundles/pull/124

Signed-off-by: Martin Malina <mmalina@redhat.com>