### PR TITLE
feat(HACBS-2225): add task to collect extra data

### DIFF
--- a/catalog/task/collect-extra-data/0.1/README.md
+++ b/catalog/task/collect-extra-data/0.1/README.md
@@ -1,0 +1,14 @@
+# apply-mapping
+
+Tekton task to collect the information added to the extraData field of the release resources.
+
+The purpose of this task is to collect all the extra data and supply it to the other task in the pipeline through
+a Tekton result. The name of this result is `extraData`.
+
+## Parameters
+
+| Name                 | Description                                        | Optional | Default value |
+|----------------------|----------------------------------------------------|----------|---------------|
+| release              | Namespaced name of the Release                     | No       | -             |
+| releasePlan          | Namespaced name of the ReleasePlan                 | No       | -             |
+| releasePlanAdmission | Namespaced name of the ReleasePlanAdmission        | No       | -             |

--- a/catalog/task/collect-extra-data/0.1/collect-extra-data.yaml
+++ b/catalog/task/collect-extra-data/0.1/collect-extra-data.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: collect-extra-data
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Tekton task to collect extra data from release resources
+  params:
+    - name: release
+      type: string
+      description: The namespaced name of the Release
+    - name: releasePlan
+      type: string
+      description: The namespaced name of the ReleasePlan
+    - name: releasePlanAdmission
+      type: string
+      description: The namespaced name of the ReleasePlanAdmission
+  results:
+    - name: extraData
+      description: |
+        Result of merging the `extraData` field of all the release resources
+  steps:
+    - name: collect-extra-data
+      image: quay.io/hacbs-release/release-utils:f486f350df43974706fc484a13bfeefc2c8fa95a
+      env:
+        - name: "RELEASE"
+          value: '$(params.release)'
+        - name: "RELEASE_PLAN"
+          value: '$(params.releasePlan)'
+        - name: "RELEASE_PLAN_ADMISSION"
+          value: '$(params.releasePlanAdmission)'
+      script: |
+        #!/usr/bin/env sh
+
+        if ! release_result=$(get-resource "test" "${RELEASE}" "{.spec.extraData}"); then
+          exit 1
+        fi
+
+        if ! release_plan_result=$(get-resource "test" "${RELEASE_PLAN}" "{.spec.extraData}"); then
+          exit 1
+        fi
+
+        if ! release_plan_admission_result=$(get-resource "test" "${RELEASE_PLAN_ADMISSION}" \
+            "{.spec.extraData}"); then
+          exit 1
+        fi
+
+        # Merge Release and ReleasePlan keys. ReleasePlan has higher priority
+        merged_output=$(merge-json "$release_result" "$release_plan_result")
+
+        # Merge now with ReleasePlanAdmission keys. ReleasePlanAdmission has higher priority
+        merged_output=$(merge-json "$release_result" "$release_plan_admission_result")
+
+        echo "$merged_output" | tee $(results.extraData.path)

--- a/catalog/task/collect-extra-data/0.1/samples/sample_collect-extra-data_TaskRun.yaml
+++ b/catalog/task/collect-extra-data/0.1/samples/sample_collect-extra-data_TaskRun.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: collect-extra-data-run
+spec:
+  params:
+    - name: release
+      value: "default/release"
+    - name: releasePlan
+      value: "default/release-plan"
+    - name: releasePlanAdmission
+      value: "default/release-plan-admission"
+  taskRef:
+    name: collect-extra-data
+    bundle: quay.io/hacbs-release/task-collect-extra-data:0.1

--- a/catalog/task/collect-extra-data/0.1/tests/run.yaml
+++ b/catalog/task/collect-extra-data/0.1/tests/run.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: collect-extra-data-run
+spec:
+  params:
+    - name: release
+      value: "default/release"
+    - name: releasePlan
+      value: "default/release-plan"
+    - name: releasePlanAdmission
+      value: "default/release-plan-admission"
+  taskRef:
+    name: collect-extra-data
+    bundle: quay.io/hacbs-release/task-collect-extra-data:0.1

--- a/catalog/task/collect-extra-data/OWNERS
+++ b/catalog/task/collect-extra-data/OWNERS
@@ -1,0 +1,1 @@
+hacbs-release@redhat.com


### PR DESCRIPTION
This commit adds a new task to collect the information in the extraData field from the Release, the ReleasePlan and the ReleasePlanAdmission resources. The data in those fields is merged, with keys being overwritten taking into account the following priority chain: RPA > RP > R.