### PR TITLE
feat(HACBS-2130): add kubernetes-actions upstream task

### DIFF
--- a/.github/workflows/tekton_bundle_push.yaml
+++ b/.github/workflows/tekton_bundle_push.yaml
@@ -7,6 +7,9 @@ on:  # yamllint disable-line rule:truthy
       - 'catalog/*/*/*/*.yaml' # E.G. catalog/pipeline/release/0.2/release.yaml
       - '!catalog/*/*/*/samples/**' # negated paths
       - '!catalog/*/*/*/tests/**'
+      - 'catalog/task/upstream/*/*/*/*.yaml' # E.G. catalog/task/upstream/tekton/kubernetes-actions/0.2/kubernetes-actions.yaml
+      - '!catalog/task/upstream/*/*/*/samples/**' # negated paths
+      - '!catalog/task/upstream/*/*/*/tests/**'
   workflow_dispatch:
 env:
   IMAGE_REGISTRY: quay.io

--- a/.github/workflows/tekton_task_tests.yaml
+++ b/.github/workflows/tekton_task_tests.yaml
@@ -5,6 +5,7 @@ on:
     branches: ['main']
     paths:
       - 'catalog/task/**'
+      - '!catalog/task/upstream/**'
 jobs:
   run-tekton-task-tests:
     name: Run Tekton Task tests

--- a/catalog/task/upstream/tekton/kubernetes-actions/0.2/README.md
+++ b/catalog/task/upstream/tekton/kubernetes-actions/0.2/README.md
@@ -1,0 +1,14 @@
+# kubernetes-actions
+
+**This task is a copy of an upstream task. The upstream task is located at
+https://github.com/tektoncd/catalog/tree/main/task/kubernetes-actions**
+
+This task is the generic kubectl CLI task which can be used to run all kinds of k8s commands.
+
+## Parameters
+
+| Name | Description | Optional | Default value |
+|------|-------------|----------|---------------|
+| script | The Kubernetes CLI script to run | Yes | kubectl $@ |
+| args | The Kubernetes CLI arguments to run | Yes | help |
+| image | Kubectl wrapper image | Yes | gcr.io/cloud-builders/kubectl@sha256:8ab94be8b2b4f3d117f02d868b39540fddd225447abf4014f7ba4765cb39f753 |

--- a/catalog/task/upstream/tekton/kubernetes-actions/0.2/kubernetes-actions.yaml
+++ b/catalog/task/upstream/tekton/kubernetes-actions/0.2/kubernetes-actions.yaml
@@ -1,0 +1,56 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: kubernetes-actions
+  labels:
+    app.kubernetes.io/version: "0.2"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.17.0"
+    tekton.dev/categories: Kubernetes
+    tekton.dev/tags: CLI, kubectl
+    tekton.dev/displayName: "kubernetes actions"
+    tekton.dev/platforms: "linux/amd64"
+spec:
+  description: >-
+    This task is the generic kubectl CLI task which can be used
+    to run all kinds of k8s commands
+  workspaces:
+    - name: manifest-dir
+      optional: true
+    - name: kubeconfig-dir
+      optional: true
+  results:
+    - name: output-result
+      description: some result can be emitted if someone wants to.
+  params:
+    - name: script
+      description: The Kubernetes CLI script to run
+      type: string
+      default: "kubectl $@"
+    - name: args
+      description: The Kubernetes CLI arguments to run
+      type: array
+      default:
+        - "help"
+    - name: image
+      default:
+        gcr.io/cloud-builders/kubectl@sha256:8ab94be8b2b4f3d117f02d868b39540fddd225447abf4014f7ba4765cb39f753
+      description: Kubectl wrapper image
+  steps:
+    - name: kubectl
+      image: $(params.image)
+      script: |
+        #!/usr/bin/env bash
+
+        [[ "$(workspaces.manifest-dir.bound)" == "true" ]] && \
+        cd $(workspaces.manifest-dir.path)
+
+        [[ "$(workspaces.kubeconfig-dir.bound)" == "true" ]] && \
+        [[ -f $(workspaces.kubeconfig-dir.path)/kubeconfig ]] && \
+        export KUBECONFIG=$(workspaces.kubeconfig-dir.path)/kubeconfig
+
+        $(params.script)
+
+      args:
+        - "$(params.args)"

--- a/catalog/task/upstream/tekton/kubernetes-actions/0.2/tests/run.yaml
+++ b/catalog/task/upstream/tekton/kubernetes-actions/0.2/tests/run.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: kubernetes-actions-run
+spec:
+  serviceAccountName: kubernetes-actions-account
+  taskRef:
+    name: kubernetes-actions
+  params:
+    - name: script
+      value: |
+        kubectl get pods
+        echo "---------"
+        kubectl get deploy

--- a/catalog/task/upstream/tekton/kubernetes-actions/OWNERS
+++ b/catalog/task/upstream/tekton/kubernetes-actions/OWNERS
@@ -1,0 +1,1 @@
+hacbs-release@redhat.com


### PR DESCRIPTION
This adds a copy of the upstream task `kubernetes-actions` to the repository. This task allows to run whatever `kubectl` command is passed as the script parameter, and the output is saved as `output-result`.