### PR TITLE
fix: adds fbcPublishingCredentials param back to the pipeline

### DIFF
--- a/catalog/pipeline/fbc-release/0.14/README.md
+++ b/catalog/pipeline/fbc-release/0.14/README.md
@@ -1,0 +1,92 @@
+# FBC Release Pipeline
+
+Tekton release pipeline to interact with FBC Pipeline
+
+## Parameters
+
+| Name | Description | Optional | Default value |
+|------|-------------|----------|---------------|
+| snapshot | The Snapshot in JSON format | No | - |
+| enterpriseContractPolicy | JSON representation of the EnterpriseContractPolicy | No | - |
+| release | The namespaced name (namespace/releaseName) of the Release custom resource initiating this pipeline execution | No | - |
+| fromIndex | The source Index image (catalog of catalogs) FBC fragment | No | - |
+| targetIndex | Index image (catalog of catalogs) the FBC fragment will be added to | No | - |
+| binaryImage | OCP binary image to be baked into the index image | Yes | "" |
+| buildTags | List of additional tags the internal index image copy should be tagged with | Yes | "[]" |
+| addArches | List of arches the index image should be built for | Yes | "[]" |
+| signingConfigMapName | The ConfigMap to be used by the signing Pipeline | Yes | "hacbs-signing-pipeline-config" |
+| fbcPublishingCredentials | Secret used to publish the built index image | Yes | "fbc-publishing-credentials" |
+| requestUpdateTimeout | Max seconds to wait until the status is updated | Yes | - |
+| buildTimeoutSeconds | Max seconds to wait until the build finishes | Yes | - |
+| verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
+
+## Changelog
+
+### Changes since 0.13
+- adds back the parameter `fbcPublishingCredentials` as different secrets
+  might be set for the same namespace
+
+### Changes since 0.12
+- the release parameter was added and the requester parameter was removed
+    - the value to use for signing is now pulled from the release resource status
+
+### Changes since 0.11
+- updates tasks that use `create-internal-request` task to 0.6 as now they need to
+  rely on its `genericResult` result
+- the task `publish-index-image` now uses `create-internal-request` so the publishing
+  is done by the cluster running the internal-services-controller
+- only executes `publish-index-image` and `sign-index-image` when genericResult result of
+  the tasks using `create-internal-request` has `fbc_opt_in=true` value set
+- removes `fbcPublishingCredentials` parameter
+- removes `overwriteFromIndex` parameter
+
+### Changes since 0.10
+- the verify_ec_task_bundle parameter was added
+    - with this addition, the verify-enterprise-contract task version is no longer static
+
+### Changes since 0.9
+- changes on the following tasks due to `create-internal-request` changes:
+    - `add-fbc-contribution-to-index-image` now accepts dynamic parameters
+    - `sign-index-image` now accepts dynamic parameters
+- changes on `publish-index-image` task to read data from its `inputDataFile` parameter
+- adds cleanup task
+
+### Changes since 0.8
+- fixes in the README.md file
+- adds param `fbcPublishingCredentials`
+- removes param `overwriteFromIndex`
+- adds new task `publish-index-image`
+
+### Changes since 0.7
+The syntax for `taskRef.bundle` and `pipelineRef.bundle` is deprecated,
+bundles resolver is used with new format.
+
+### Changes since 0.6
+- adds sign-index-image task
+- refactor task and change its reference name from `create-internal-request`
+  to `add-fbc-contribution-to-index-image`
+- adds `requester` and `signingConfigMapName` parameters
+- removes `resolvedIndexImage` result
+
+### Changes since 0.5
+- updates `create-internal-request` task version to 0.3
+
+### Changes since 0.4
+- updates `create-internal-request` task version to 0.2
+- adds `resolvedIndexImage` result
+
+### Changes since 0.3
+- removes param `fbcFragment`
+- adds param `buildTimeoutSeconds`
+
+### Changes since 0.2
+- renames the pipeline to `fbc-release`
+- forces the pipeline to run after `verify-enterprise-contract`
+
+### Changes since 0.1
+- adds param `requestUpdateTimeout`
+- adds task result values to the pipeline results
+  - `requestMessage` gets `$(tasks.create-internal-request.results.requestMessage)`
+  - `requestReason` gets `$(tasks.create-internal-request.results.requestReason)`
+  - `requestResults` gets `$(tasks.create-internal-request.results.requestResults)`
+- changes `verify-enterprise-contract` task version

--- a/catalog/pipeline/fbc-release/0.14/fbc-release.yaml
+++ b/catalog/pipeline/fbc-release/0.14/fbc-release.yaml
@@ -1,0 +1,239 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: fbc-release
+  labels:
+    app.kubernetes.io/version: "0.14"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Tekton release pipeline to interact with FBC Pipeline
+  params:
+    - name: snapshot
+      type: string
+      description: The Snapshot in JSON format
+    - name: enterpriseContractPolicy
+      type: string
+      description: JSON representation of the EnterpriseContractPolicy
+    - name: release
+      type: string
+      description:
+        The namespaced name (namespace/releaseName) of the Release custom resource initiating this pipeline execution
+    - name: fromIndex
+      type: string
+      description: The source Index image (catalog of catalogs) FBC fragment
+    - name: targetIndex
+      type: string
+      description: Index image (catalog of catalogs) the FBC fragment will be added to
+    - name: binaryImage
+      type: string
+      default: ""
+      description: OCP binary image to be baked into the index image
+    - name: buildTags
+      type: string
+      default: "[]"
+      description: List of additional tags the internal index image copy should be tagged with
+    - name: addArches
+      type: string
+      default: "[]"
+      description: List of arches the index image should be built for
+    - name: signingConfigMapName
+      type: string
+      default: "hacbs-signing-pipeline-config"
+      description: The ConfigMap to be used by the signing Pipeline
+    - name: fbcPublishingCredentials
+      type: string
+      default: "fbc-publishing-credentials"
+      description: Secret used to publish the built index image
+    - name: requestUpdateTimeout
+      type: string
+      description: Max seconds to wait until the status is updated
+    - name: buildTimeoutSeconds
+      type: string
+      description: Max seconds to wait until the build finishes
+    - name: verify_ec_task_bundle
+      type: string
+      description: The location of the bundle containing the verify-enterprise-contract task
+  workspaces:
+    - name: release-workspace
+  results:
+    - name: requestMessage
+      value: $(tasks.add-fbc-contribution-to-index-image.results.requestMessage)
+    - name: requestReason
+      value: $(tasks.add-fbc-contribution-to-index-image.results.requestReason)
+  tasks:
+    - name: verify-enterprise-contract
+      taskRef:
+        resolver: "bundles"
+        params:
+          - name: bundle
+            value: $(params.verify_ec_task_bundle)
+          - name: kind
+            value: task
+          - name: name
+            value: verify-enterprise-contract
+      params:
+        - name: IMAGES
+          value: $(params.snapshot)
+        - name: SSL_CERT_DIR
+          value: /var/run/secrets/kubernetes.io/serviceaccount
+        - name: POLICY_CONFIGURATION
+          value: $(params.enterpriseContractPolicy)
+        - name: STRICT
+          value: "1"
+    - name: add-fbc-contribution-to-index-image
+      workspaces:
+        - name: input
+          workspace: release-workspace
+      taskRef:
+        resolver: "bundles"
+        params:
+          - name: bundle
+            value: quay.io/hacbs-release/task-create-internal-request:0.6
+          - name: kind
+            value: task
+          - name: name
+            value: create-internal-request
+      params:
+        - name: pipelineRunName
+          value: $(context.pipelineRun.name)
+        - name: request
+          value: "iib"
+        - name: updateGenericResult
+          value: "true"
+        - name: params
+          value:
+            - name: binaryImage
+              value: "$(params.binaryImage)"
+            - name: fromIndex
+              value: "$(params.fromIndex)"
+            - name: buildTags
+              value: "$(params.buildTags)"
+            - name: addArches
+              value: "$(params.addArches)"
+            - name: buildTimeoutSeconds
+              value: "$(params.buildTimeoutSeconds)"
+            - name: fbcFragment
+              value: '$(params.snapshot)'
+              jsonKey: ".components[0].containerImage"
+      runAfter:
+        - verify-enterprise-contract
+    - name: extract-requester-from-release
+      taskRef:
+        resolver: "bundles"
+        params:
+          - name: bundle
+            value: quay.io/hacbs-release/task-kubernetes-actions:0.2
+          - name: kind
+            value: task
+          - name: name
+            value: kubernetes-actions
+      params:
+        - name: image
+          value: "quay.io/hacbs-release/cloud-builders-kubectl\
+            @sha256:8ab94be8b2b4f3d117f02d868b39540fddd225447abf4014f7ba4765cb39f753"
+        - name: script
+          value: |
+            set -x
+
+            NAMESPACE=$(echo $(params.release) | cut -d '/' -f 1)
+            NAME=$(echo $(params.release) | cut -d '/' -f 2)
+
+            AUTHOR=$(kubectl get release ${NAME} -n ${NAMESPACE} \
+            -o=jsonpath='{.status.attribution.author}' | tee $(results.output-result.path))
+
+            if [[ ${AUTHOR} == "" ]] ; then exit 1 ; fi
+    - name: sign-index-image
+      workspaces:
+        - name: input
+          workspace: release-workspace
+      taskRef:
+        resolver: "bundles"
+        params:
+          - name: bundle
+            value: quay.io/hacbs-release/task-create-internal-request:0.6
+          - name: kind
+            value: task
+          - name: name
+            value: create-internal-request
+      params:
+        - name: pipelineRunName
+          value: $(context.pipelineRun.name)
+        - name: inputDataFile
+          value: $(tasks.add-fbc-contribution-to-index-image.results.requestResultsFile)
+        - name: request
+          value: "hacbs-signing-pipeline"
+        - name: params
+          value:
+            - name: manifest_digest
+              value: "sharedRequestFile:json:.jsonBuildInfo"
+              jsonKey: ".index_image_resolved"
+            - name: pipeline_image
+              value: "quay.io/redhat-isv/operator-pipelines-images:released"
+            - name: reference
+              value: $(params.targetIndex)
+            - name: requester
+              value: $(tasks.extract-requester-from-release.results.output-result)
+            - name: config_map_name
+              value: $(params.signingConfigMapName)
+      when:
+        - input: "$(tasks.add-fbc-contribution-to-index-image.results.genericResult)"
+          operator: in
+          values: ["fbc_opt_in=true"]
+    - name: publish-index-image
+      workspaces:
+        - name: input
+          workspace: release-workspace
+      taskRef:
+        resolver: "bundles"
+        params:
+          - name: bundle
+            value: quay.io/hacbs-release/task-create-internal-request:0.6
+          - name: kind
+            value: task
+          - name: name
+            value: create-internal-request
+      params:
+        - name: pipelineRunName
+          value: $(context.pipelineRun.name)
+        - name: inputDataFile
+          value: $(tasks.add-fbc-contribution-to-index-image.results.requestResultsFile)
+        - name: request
+          value: "publish-index-image-pipeline"
+        - name: params
+          value:
+            - name: sourceIndex
+              value: "sharedRequestFile:json:.jsonBuildInfo"
+              jsonKey: ".index_image_resolved"
+            - name: targetIndex
+              value: $(params.targetIndex)
+            - name: publishingCredentials
+              value: $(params.fbcPublishingCredentials)
+            - name: retries
+              value: "0"
+      when:
+        - input: "$(tasks.add-fbc-contribution-to-index-image.results.genericResult)"
+          operator: in
+          values: ["fbc_opt_in=true"]
+      runAfter:
+        - sign-index-image
+  finally:
+    - name: cleanup
+      taskRef:
+        resolver: "bundles"
+        params:
+          - name: bundle
+            value: quay.io/hacbs-release/task-cleanup-workspace:main
+          - name: kind
+            value: task
+          - name: name
+            value: cleanup-workspace
+      params:
+        - name: subdirectory
+          value: "internal-request"
+      workspaces:
+        - name: input
+          workspace: release-workspace

--- a/catalog/pipeline/fbc-release/0.14/samples/sample_release_PipelineRun.yaml
+++ b/catalog/pipeline/fbc-release/0.14/samples/sample_release_PipelineRun.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: fbc-release-run-empty-params
+spec:
+  params:
+    - name: snapshot
+      value: ""
+    - name: enterpriseContractPolicy
+      value: ""
+    - name: release
+      value: ""
+    - name: fromIndex
+      value: ""
+    - name: targetIndex
+      value: ""
+    - name: binaryImage
+      value: ""
+    - name: buildTags
+      value: ""
+    - name: addArches
+      value: ""
+    - name: signingConfigMapName
+      value: ""
+    - name: fbcPublishingCredentials
+      value: ""
+    - name: requestUpdateTimeout
+      value: ""
+    - name: buildTimeoutSeconds
+      value: ""
+    - name: verify_ec_task_bundle
+      value: ""
+  pipelineRef:
+    resolver: "bundles"
+    params:
+      - name: bundle
+        value: quay.io/hacbs-release/pipeline-fbc-release:0.14
+      - name: kind
+        value: pipeline
+      - name: name
+        value: fbc-release

--- a/catalog/pipeline/fbc-release/0.14/tests/run.yaml
+++ b/catalog/pipeline/fbc-release/0.14/tests/run.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: fbc-release-run-empty-params
+spec:
+  params:
+    - name: snapshot
+      value: ""
+    - name: enterpriseContractPolicy
+      value: ""
+    - name: release
+      value: ""
+    - name: fromIndex
+      value: ""
+    - name: targetIndex
+      value: ""
+    - name: binaryImage
+      value: ""
+    - name: buildTags
+      value: ""
+    - name: addArches
+      value: ""
+    - name: signingConfigMapName
+      value: ""
+    - name: fbcPublishingCredentials
+      value: ""
+    - name: requestUpdateTimeout
+      value: ""
+    - name: buildTimeoutSeconds
+      value: ""
+    - name: verify_ec_task_bundle
+      value: ""
+  pipelineRef:
+    resolver: "bundles"
+    params:
+      - name: bundle
+        value: quay.io/hacbs-release/pipeline-fbc-release:0.14
+      - name: kind
+        value: pipeline
+      - name: name
+        value: fbc-release


### PR DESCRIPTION
The version `0.12` removes the param `fbcPublishingCredentials` but it is actually required
as we might need to set different publishing secrets per environment in the same namespace 
(ie. stage and pre-GA) in stage *cluster*.