### PR TITLE
refactor(HACBS-2375): update utils image in push-sbom-to-pyxis task

### DIFF
--- a/catalog/task/push-sbom-to-pyxis/0.1/push-sbom-to-pyxis.yaml
+++ b/catalog/task/push-sbom-to-pyxis/0.1/push-sbom-to-pyxis.yaml
@@ -58,7 +58,7 @@ spec:
 
     - name: push-sbom-files-to-pyxis
       image:
-        quay.io/hacbs-release/release-utils:5b1a1cd9fd68625cab5573ce62e0d87e6f93f341
+        quay.io/hacbs-release/release-utils:7c19cfb26869fb2c76c3a6b0eaad6408ead66c56
       env:
         - name: pyxisCert
           valueFrom:


### PR DESCRIPTION
The upload_sbom script was refactored to account for changes in Pyxis api (some embedded objects are being removed):

https://github.com/redhat-appstudio/release-service-utils/pull/41

The functionality is identical, so a new version should not be needed.