### PR TITLE
refactor(HACBS-2290): pass absolute path to ec task

### DIFF
--- a/catalog/pipeline/deploy-release/0.4/deploy-release.yaml
+++ b/catalog/pipeline/deploy-release/0.4/deploy-release.yaml
@@ -73,7 +73,7 @@ spec:
             value: verify-enterprise-contract
       params:
         - name: IMAGES
-          value: "snapshot_spec.json"
+          value: "$(workspaces.data.path)/snapshot_spec.json"
         - name: SSL_CERT_DIR
           value: /var/run/secrets/kubernetes.io/serviceaccount
         - name: POLICY_CONFIGURATION

--- a/catalog/pipeline/fbc-release/0.16/fbc-release.yaml
+++ b/catalog/pipeline/fbc-release/0.16/fbc-release.yaml
@@ -118,7 +118,7 @@ spec:
             value: verify-enterprise-contract
       params:
         - name: IMAGES
-          value: "snapshot_spec.json"
+          value: "$(workspaces.data.path)/snapshot_spec.json"
         - name: SSL_CERT_DIR
           value: /var/run/secrets/kubernetes.io/serviceaccount
         - name: POLICY_CONFIGURATION

--- a/catalog/pipeline/push-to-external-registry/0.12/push-to-external-registry.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.12/push-to-external-registry.yaml
@@ -159,7 +159,7 @@ spec:
             value: verify-enterprise-contract
       params:
         - name: IMAGES
-          value: "mapped_snapshot.json"
+          value: "$(workspaces.data.path)/mapped_snapshot.json"
         - name: SSL_CERT_DIR
           value: /var/run/secrets/kubernetes.io/serviceaccount
         - name: POLICY_CONFIGURATION

--- a/catalog/pipeline/release/0.15/release.yaml
+++ b/catalog/pipeline/release/0.15/release.yaml
@@ -141,7 +141,7 @@ spec:
             value: verify-enterprise-contract
       params:
         - name: IMAGES
-          value: "mapped_snapshot.json"
+          value: "$(workspaces.data.path)/mapped_snapshot.json"
         - name: SSL_CERT_DIR
           value: /var/run/secrets/kubernetes.io/serviceaccount
         - name: POLICY_CONFIGURATION


### PR DESCRIPTION
In order for the verify-enterprise-contract task to be backwards compatible, they need us to pass the absolute path to the snapshot, not just the filename.