### PR TITLE
chore: update utils image in push sbom task

### DIFF
--- a/catalog/task/push-sbom-to-pyxis/0.2/push-sbom-to-pyxis.yaml
+++ b/catalog/task/push-sbom-to-pyxis/0.2/push-sbom-to-pyxis.yaml
@@ -68,7 +68,7 @@ spec:
 
     - name: push-sbom-files-to-pyxis
       image:
-        quay.io/hacbs-release/release-utils:5b1a1cd9fd68625cab5573ce62e0d87e6f93f341
+        quay.io/hacbs-release/release-utils:7845accbe425ac14747c8ee761e67d3ef11a824e
       env:
         - name: pyxisCert
           valueFrom:


### PR DESCRIPTION
I didn't realize there were two image lines in [!140](https://github.com/redhat-appstudio/release-service-bundles/pull/141)