### PR TITLE
chore(HACBS-2271): update images in push-sbom-to-pyxis task

### DIFF
--- a/catalog/task/push-sbom-to-pyxis/0.2/push-sbom-to-pyxis.yaml
+++ b/catalog/task/push-sbom-to-pyxis/0.2/push-sbom-to-pyxis.yaml
@@ -36,7 +36,7 @@ spec:
   steps:
     - name: download-sbom-files
       image:
-        quay.io/hacbs-release/release-utils:7845accbe425ac14747c8ee761e67d3ef11a824e
+        quay.io/hacbs-release/release-utils:de40e7e7b9d90de5cff5a4266d429f633bd1a1c2
       volumeMounts:
         - mountPath: /workdir
           name: workdir
@@ -68,7 +68,7 @@ spec:
 
     - name: push-sbom-files-to-pyxis
       image:
-        quay.io/hacbs-release/release-utils:7845accbe425ac14747c8ee761e67d3ef11a824e
+        quay.io/hacbs-release/release-utils:de40e7e7b9d90de5cff5a4266d429f633bd1a1c2
       env:
         - name: pyxisCert
           valueFrom:


### PR DESCRIPTION
The updated image contains improvements from
https://github.com/redhat-appstudio/release-service-utils/pull/46