### PR TITLE
feat(HACBS-2292): get ocp version from an image

### DIFF
--- a/catalog/task/get-ocp-version/0.1/README.md
+++ b/catalog/task/get-ocp-version/0.1/README.md
@@ -1,0 +1,9 @@
+# get-ocp-version
+
+Tekton task to collect OCP version tag from FBC fragment using `skopeo inspect`.
+
+## Parameters
+
+| Name | Description | Optional | Default value |
+|------|-------------|----------|---------------|
+| fbcFragment | A FBC container Image | No | - |

--- a/catalog/task/get-ocp-version/0.1/get-ocp-version.yaml
+++ b/catalog/task/get-ocp-version/0.1/get-ocp-version.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: get-ocp-version
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Tekton task to collect OCP version tag from FBC fragment using `skopeo inspect`
+  params:
+    - name: fbcFragment
+      description: An FBC image to inspect
+      type: string
+  results:
+    - name: stored-version
+      description: Store OCP version number from given Image
+  steps:
+    - name: get-ocp-version
+      image: quay.io/hacbs-release/release-utils:4d8649dbb2b626f5fe9f4ff83c1bc3be268fad31
+      script: |
+       #!/usr/bin/env sh
+       set -eux
+
+        # The value to be checked
+        value=$(skopeo inspect --raw docker://"$(params.fbcFragment)" \
+         | jq '.annotations."org.opencontainers.image.base.name"' | cut -d: -f2 | sed 's/"//g')
+
+        # Define the regular expression
+        pattern="^v[0-9]\.[0-9]+$"
+
+        # Check if the value matches the pattern
+        if ! echo ${value} | grep -Eq ${pattern}; then
+            echo "Invalid format or value does not exist or does not match the required pattern."
+            exit 1
+        fi
+        echo "Valid format."
+        echo "$value" | tee $(results.stored-version.path)

--- a/catalog/task/get-ocp-version/0.1/samples/sample_get-ocp-version_TaskRun.yaml
+++ b/catalog/task/get-ocp-version/0.1/samples/sample_get-ocp-version_TaskRun.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: get-ocp-version-run-empty-params
+spec:
+  params:
+    - name: fbcFragment
+      value: ""
+  taskRef:
+    resolver: "bundles"
+    params:
+      - name: bundle
+        value: quay.io/hacbs-release/task-get-ocp-version:0.1
+      - name: kind
+        value: task
+      - name: name
+        value: get-ocp-version

--- a/catalog/task/get-ocp-version/0.1/tests/test-get-ocp-version.yaml
+++ b/catalog/task/get-ocp-version/0.1/tests/test-get-ocp-version.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: test-get-ocp-version
+spec:
+  description: |
+    Run the get-ocp-version task with a fbcFragment FBC Image
+    and verify that OCP-Version is been stored as expected
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: run-task
+      taskRef:
+        name: get-ocp-version
+      params:
+        - name: fbcFragment
+          value: >-
+            quay.io/hacbs-release-tests/managed-release-team-tenant/sample-fbc-application/sample-fbc-component@sha256:3bab7aa91d6e62c6e6f8cd6e701b78124d477eab3d8d1e1d3bce59c81204b1d7
+    - name: check-result
+      params:
+        - name: stored-version
+          value: $(tasks.run-task.results.stored-version)
+      runAfter:
+        - run-task
+      taskSpec:
+        params:
+          - name: stored-version
+        steps:
+          - name: check-result
+            image: quay.io/hacbs-release/release-utils:4d8649dbb2b626f5fe9f4ff83c1bc3be268fad31
+            env:
+              - name: "OCP_VERSION"
+                value: '$(params.stored-version)'
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              echo "Task result contains the valid OCP version number"
+              test $(echo $OCP_VERSION) == "v4.12"

--- a/catalog/task/get-ocp-version/OWNERS
+++ b/catalog/task/get-ocp-version/OWNERS
@@ -1,0 +1,1 @@
+hacbs-release@redhat.com


### PR DESCRIPTION
This PR will add a new task to store the OCP version from the fbcFragment (image) and store it as a task result. 
In HACBS-2293 this stored result will validate the correct version being used in the strategy for fromIndex and targetIndex.