### PR TITLE
fix: tekton task test triggering

### DIFF
--- a/.github/workflows/tekton_task_tests.yaml
+++ b/.github/workflows/tekton_task_tests.yaml
@@ -38,8 +38,6 @@ jobs:
           kubectl get pods --namespace tekton-pipelines
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: Install tkn
-        uses: ./.github/actions/install-tkn
       - name: Get changed dirs
         id: changed-dirs
         uses: tj-actions/changed-files@v35
@@ -51,11 +49,17 @@ jobs:
       - name: Show changed dirs
         run: |
           echo ${{ steps.changed-dirs.outputs.all_changed_files }}
+      - name: Install tkn
+        if: steps.changed-dirs.outputs.any_changed == 'true'
+        uses: ./.github/actions/install-tkn
       - name: Install Release Service CRDs
+        if: steps.changed-dirs.outputs.any_changed == 'true'
         run: .github/scripts/install_crds.sh
       - name: Install RBAC for CRDs
+        if: steps.changed-dirs.outputs.any_changed == 'true'
         run: kubectl apply -f .github/resources/crd_rbac.yaml
       - name: Test Tekton tasks
+        if: steps.changed-dirs.outputs.any_changed == 'true'
         run: .github/scripts/test_tekton_tasks.sh
         env:
           TASK_DIRS: ${{ steps.changed-dirs.outputs.all_changed_files }}


### PR DESCRIPTION
If the only change to the catalog/task directory is removing stuff, the tekton task tests do not need to run.