### PR TITLE
feat(HACBS-2431): enable task test pre hooks

### DIFF
--- a/.github/scripts/test_tekton_tasks.sh
+++ b/.github/scripts/test_tekton_tasks.sh
@@ -78,6 +78,12 @@ do
     continue
   fi
 
+  if [ -f ${TESTS_DIR}/pre-apply-task-hook.sh ]
+  then
+    echo Found pre-apply-task-hook.sh file in dir: $TESTS_DIR. Executing...
+    ${TESTS_DIR}/pre-apply-task-hook.sh
+  fi
+
   echo "  Installing task"
   kubectl apply -f $TASK_PATH
 


### PR DESCRIPTION
This commit sets up a framework to allow each test directory to have its own pre-apply-task-hook.sh file, following upstream standards. If the file exists, it will be executed before the test files.