### PR TITLE
refactor: only run collect-data prereqs for that task

### DIFF
--- a/.github/workflows/tekton_task_tests.yaml
+++ b/.github/workflows/tekton_task_tests.yaml
@@ -52,12 +52,6 @@ jobs:
       - name: Install tkn
         if: steps.changed-dirs.outputs.any_changed == 'true'
         uses: ./.github/actions/install-tkn
-      - name: Install Release Service CRDs
-        if: steps.changed-dirs.outputs.any_changed == 'true'
-        run: .github/scripts/install_crds.sh
-      - name: Install RBAC for CRDs
-        if: steps.changed-dirs.outputs.any_changed == 'true'
-        run: kubectl apply -f .github/resources/crd_rbac.yaml
       - name: Test Tekton tasks
         if: steps.changed-dirs.outputs.any_changed == 'true'
         run: .github/scripts/test_tekton_tasks.sh

--- a/catalog/task/collect-data/0.1/tests/pre-apply-task-hook.sh
+++ b/catalog/task/collect-data/0.1/tests/pre-apply-task-hook.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# Install the CRDs so we can create/get them
+.github/scripts/install_crds.sh
+
+# Add RBAC so that the SA executing the tests can retrieve CRs
+kubectl apply -f .github/resources/crd_rbac.yaml


### PR DESCRIPTION
This commit moves the pre reqs for the collect-data tests from running for any task test to only running for the collect-data task tests.