### PR TITLE
fix(RHTAPBUGS-560): enable retry for upload_sbom script

### DIFF
--- a/catalog/task/push-sbom-to-pyxis/0.2/push-sbom-to-pyxis.yaml
+++ b/catalog/task/push-sbom-to-pyxis/0.2/push-sbom-to-pyxis.yaml
@@ -107,5 +107,5 @@ spec:
 
         for FILE in *.json; do
           echo Uploading sbom to Pyxis: $FILE
-          upload_sbom --sbom-path $FILE
+          upload_sbom --retry --sbom-path $FILE
         done


### PR DESCRIPTION
This was somehow missed when we added the retry option to the script as part of HACBS-2271 .

The PR that was updating the push-sbom-to-pyxis task only updated the release-util image version
but forgot to actually enable the retry:
https://github.com/redhat-appstudio/release-service-bundles/pull/143

For reference, here's the PR that added the `--retry` option: https://github.com/redhat-appstudio/release-service-utils/pull/46