### PR TITLE
refactor(HACBS-2456): use git resolvers instead of bundle resolvers

### DIFF
--- a/catalog/pipeline/deploy-release/0.5/README.md
+++ b/catalog/pipeline/deploy-release/0.5/README.md
@@ -1,0 +1,34 @@
+# Release Pipeline
+
+Tekton pipeline to verify Snapshot prior to Deployment
+
+## Parameters
+
+| Name | Description | Optional | Default value |
+|------|-------------|----------|---------------|
+| release | The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution | No | - |
+| releaseplan | The namespaced name (namespace/name) of the releasePlan | No | - |
+| releaseplanadmission | The namespaced name (namespace/name) of the releasePlanAdmission | No | - |
+| releasestrategy | The namespaced name (namespace/name) of the releaseStrategy | No | - |
+| snapshot | The namespaced name (namespace/name) of the snapshot | No | - |
+| enterpriseContractPolicy | JSON representation of the policy to be applied when validating the enterprise contract | No | - |
+| verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
+
+## Changes since 0.4
+- git resolvers are used in place of release bundle resolvers
+
+## Changes since 0.3
+- the collect-data task was added
+    - this includes adding the required parameters release, releaseplan, releaseplanadmission,
+      and releasestrategy as pipeline parameters
+    - a workspace is now mounted by the pipeline as required by this task
+- the snapshot parameter is now a namespaced name instead of a JSON string
+
+## Changes since 0.2
+- the verify_ec_task_bundle parameter was added
+    - with this addition, the verify-enterprise-contract task version is no longer static
+
+## Changes since 0.1
+
+The syntax for `taskRef.bundle` and `pipelineRef.bundle` is deprecated,
+bundles resolver is used with new format.

--- a/catalog/pipeline/deploy-release/0.5/deploy-release.yaml
+++ b/catalog/pipeline/deploy-release/0.5/deploy-release.yaml
@@ -1,0 +1,87 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: deploy-release
+  labels:
+    app.kubernetes.io/version: "0.5"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Tekton pipeline to verify Snapshot prior to Deployment
+  params:
+    - name: release
+      type: string
+      description:
+        The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution
+    - name: releaseplan
+      type: string
+      description: The namespaced name (namespace/name) of the releasePlan
+    - name: releaseplanadmission
+      type: string
+      description: The namespaced name (namespace/name) of the releasePlanAdmission
+    - name: releasestrategy
+      type: string
+      description: The namespaced name (namespace/name) of the releaseStrategy
+    - name: snapshot
+      type: string
+      description: The namespaced name (namespace/name) of the snapshot
+    - name: enterpriseContractPolicy
+      type: string
+      description: JSON representation of the EnterpriseContractPolicy
+    - name: verify_ec_task_bundle
+      type: string
+      description: The location of the bundle containing the verify-enterprise-contract task
+  workspaces:
+    - name: release-workspace
+  tasks:
+    - name: collect-data
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/collect-data/0.1/collect-data.yaml
+      params:
+        - name: release
+          value: $(params.release)
+        - name: releaseplan
+          value: $(params.releaseplan)
+        - name: releaseplanadmission
+          value: $(params.releaseplanadmission)
+        - name: releasestrategy
+          value: $(params.releasestrategy)
+        - name: snapshot
+          value: $(params.snapshot)
+      workspaces:
+        - name: data
+          workspace: release-workspace
+    - name: verify-enterprise-contract
+      taskRef:
+        resolver: "bundles"
+        params:
+          - name: bundle
+            value: $(params.verify_ec_task_bundle)
+          - name: kind
+            value: task
+          - name: name
+            value: verify-enterprise-contract
+      params:
+        - name: IMAGES
+          value: "$(workspaces.data.path)/snapshot_spec.json"
+        - name: SSL_CERT_DIR
+          value: /var/run/secrets/kubernetes.io/serviceaccount
+        - name: POLICY_CONFIGURATION
+          value: $(params.enterpriseContractPolicy)
+        - name: STRICT
+          value: "1"
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - collect-data

--- a/catalog/pipeline/deploy-release/0.5/samples/sample_release_PipelineRun.yaml
+++ b/catalog/pipeline/deploy-release/0.5/samples/sample_release_PipelineRun.yaml
@@ -1,23 +1,25 @@
 ---
 apiVersion: tekton.dev/v1beta1
-kind: TaskRun
+kind: PipelineRun
 metadata:
-  name: sign-index-image-run-empty-params
+  name: release-run-empty-params
 spec:
   params:
-    - name: requestJsonResults
+    - name: release
       value: ""
-    - name: requestUpdateTimeout
+    - name: releaseplan
       value: ""
-    - name: signingPipelineImage
+    - name: releaseplanadmission
       value: ""
-    - name: requester
+    - name: releasestrategy
       value: ""
-    - name: configMapName
+    - name: snapshot
       value: ""
-    - name: pipelineRunName
+    - name: enterpriseContractPolicy
       value: ""
-  taskRef:
+    - name: verify_ec_task_bundle
+      value: ""
+  pipelineRef:
     resolver: "git"
     params:
       - name: url
@@ -25,4 +27,4 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: catalog/task/sign-index-image/0.1/sign-index-image.yaml
+        value: catalog/pipeline/deploy-release/0.5/deploy-release.yaml

--- a/catalog/pipeline/deploy-release/0.5/tests/run.yaml
+++ b/catalog/pipeline/deploy-release/0.5/tests/run.yaml
@@ -1,23 +1,25 @@
 ---
 apiVersion: tekton.dev/v1beta1
-kind: TaskRun
+kind: PipelineRun
 metadata:
-  name: sign-index-image-run-empty-params
+  name: release-run-empty-params
 spec:
   params:
-    - name: requestJsonResults
+    - name: release
       value: ""
-    - name: requestUpdateTimeout
+    - name: releaseplan
       value: ""
-    - name: signingPipelineImage
+    - name: releaseplanadmission
       value: ""
-    - name: requester
+    - name: releasestrategy
       value: ""
-    - name: configMapName
+    - name: snapshot
       value: ""
-    - name: pipelineRunName
+    - name: enterpriseContractPolicy
       value: ""
-  taskRef:
+    - name: verify_ec_task_bundle
+      value: ""
+  pipelineRef:
     resolver: "git"
     params:
       - name: url
@@ -25,4 +27,4 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: catalog/task/sign-index-image/0.1/sign-index-image.yaml
+        value: catalog/pipeline/deploy-release/0.5/deploy-release.yaml

--- a/catalog/pipeline/fbc-release/0.17/README.md
+++ b/catalog/pipeline/fbc-release/0.17/README.md
@@ -1,0 +1,111 @@
+# FBC Release Pipeline
+
+Tekton release pipeline to interact with FBC Pipeline
+
+## Parameters
+
+| Name | Description | Optional | Default value |
+|------|-------------|----------|---------------|
+| release | The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution | No | - |
+| releaseplan | The namespaced name (namespace/name) of the releasePlan | No | - |
+| releaseplanadmission | The namespaced name (namespace/name) of the releasePlanAdmission | No | - |
+| releasestrategy | The namespaced name (namespace/name) of the releaseStrategy | No | - |
+| snapshot | The namespaced name (namespace/name) of the snapshot | No | - |
+| enterpriseContractPolicy | JSON representation of the EnterpriseContractPolicy | No | - |
+| fromIndex | The source Index image (catalog of catalogs) FBC fragment | No | - |
+| targetIndex | Index image (catalog of catalogs) the FBC fragment will be added to | No | - |
+| binaryImage | OCP binary image to be baked into the index image | Yes | "" |
+| buildTags | List of additional tags the internal index image copy should be tagged with | Yes | "[]" |
+| addArches | List of arches the index image should be built for | Yes | "[]" |
+| signingConfigMapName | The ConfigMap to be used by the signing Pipeline | Yes | "hacbs-signing-pipeline-config" |
+| iibServiceConfigSecret | Secret that contains IIB's service configuration | Yes | "iib-services-config" |
+| iibOverwriteFromIndexCredential | Secret that stores IIB's overwrite_from_index_token parameter value | Yes | "iib-overwrite-fromimage-credentials" |
+| fbcPublishingCredentials | Secret used to publish the built index image | Yes | "fbc-publishing-credentials" |
+| requestUpdateTimeout | Max seconds to wait until the status is updated | Yes | - |
+| buildTimeoutSeconds | Max seconds to wait until the build finishes | Yes | - |
+| verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
+
+## Changelog
+
+### Changes since 0.16
+- git resolvers are used in place of release bundle resolvers
+
+### Changes since 0.15
+- the collect-data task was added
+    - this includes adding the required parameters releaseplan, releaseplanadmission, and
+      releasestrategy as pipeline parameters
+- the snapshot parameter is now a namespaced name instead of a JSON string
+    - task versions were updated in accordance with this change
+
+### Changes since 0.14
+- adds parameters `iibServiceConfigSecret` and `iibOverwriteFromIndexCredential`
+  to enable the build of pre-GA and prod FBC components in the same namespace
+
+### Changes since 0.13
+- adds back the parameter `fbcPublishingCredentials` as different secrets
+  might be set for the same namespace
+
+### Changes since 0.12
+- the release parameter was added and the requester parameter was removed
+    - the value to use for signing is now pulled from the release resource status
+
+### Changes since 0.11
+- updates tasks that use `create-internal-request` task to 0.6 as now they need to
+  rely on its `genericResult` result
+- the task `publish-index-image` now uses `create-internal-request` so the publishing
+  is done by the cluster running the internal-services-controller
+- only executes `publish-index-image` and `sign-index-image` when genericResult result of
+  the tasks using `create-internal-request` has `fbc_opt_in=true` value set
+- removes `fbcPublishingCredentials` parameter
+- removes `overwriteFromIndex` parameter
+
+### Changes since 0.10
+- the verify_ec_task_bundle parameter was added
+    - with this addition, the verify-enterprise-contract task version is no longer static
+
+### Changes since 0.9
+- changes on the following tasks due to `create-internal-request` changes:
+    - `add-fbc-contribution-to-index-image` now accepts dynamic parameters
+    - `sign-index-image` now accepts dynamic parameters
+- changes on `publish-index-image` task to read data from its `inputDataFile` parameter
+- adds cleanup task
+
+### Changes since 0.8
+- fixes in the README.md file
+- adds param `fbcPublishingCredentials`
+- removes param `overwriteFromIndex`
+- adds new task `publish-index-image`
+
+### Changes since 0.7
+The syntax for `taskRef.bundle` and `pipelineRef.bundle` is deprecated,
+bundles resolver is used with new format.
+
+### Changes since 0.6
+- adds sign-index-image task
+- refactor task and change its reference name from `create-internal-request`
+  to `add-fbc-contribution-to-index-image`
+- adds `requester` and `signingConfigMapName` parameters
+- removes `resolvedIndexImage` result
+
+### Changes since 0.5
+- updates `create-internal-request` task version to 0.3
+
+### Changes since 0.4
+- updates `create-internal-request` task version to 0.2
+- adds `resolvedIndexImage` result
+
+### Changes since 0.3
+- removes param `fbcFragment`
+- adds param `buildTimeoutSeconds`
+
+### Changes since 0.2
+- renames the pipeline to `fbc-release`
+- forces the pipeline to run after `verify-enterprise-contract`
+
+### Changes since 0.1
+- adds param `requestUpdateTimeout`
+- adds task result values to the pipeline results
+  - `requestMessage` gets `$(tasks.create-internal-request.results.requestMessage)`
+  - `requestReason` gets `$(tasks.create-internal-request.results.requestReason)`
+  - `requestResults` gets `$(tasks.create-internal-request.results.requestResults)`
+- changes `verify-enterprise-contract` task version

--- a/catalog/pipeline/fbc-release/0.17/fbc-release.yaml
+++ b/catalog/pipeline/fbc-release/0.17/fbc-release.yaml
@@ -1,0 +1,288 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: fbc-release
+  labels:
+    app.kubernetes.io/version: "0.17"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Tekton release pipeline to interact with FBC Pipeline
+  params:
+    - name: release
+      type: string
+      description:
+        The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution
+    - name: releaseplan
+      type: string
+      description: The namespaced name (namespace/name) of the releasePlan
+    - name: releaseplanadmission
+      type: string
+      description: The namespaced name (namespace/name) of the releasePlanAdmission
+    - name: releasestrategy
+      type: string
+      description: The namespaced name (namespace/name) of the releaseStrategy
+    - name: snapshot
+      type: string
+      description: The namespaced name (namespace/name) of the snapshot
+    - name: enterpriseContractPolicy
+      type: string
+      description: JSON representation of the EnterpriseContractPolicy
+    - name: fromIndex
+      type: string
+      description: The source Index image (catalog of catalogs) FBC fragment
+    - name: targetIndex
+      type: string
+      description: Index image (catalog of catalogs) the FBC fragment will be added to
+    - name: binaryImage
+      type: string
+      default: ""
+      description: OCP binary image to be baked into the index image
+    - name: buildTags
+      type: string
+      default: "[]"
+      description: List of additional tags the internal index image copy should be tagged with
+    - name: addArches
+      type: string
+      default: "[]"
+      description: List of arches the index image should be built for
+    - name: signingConfigMapName
+      type: string
+      default: "hacbs-signing-pipeline-config"
+      description: The ConfigMap to be used by the signing Pipeline
+    - name: iibServiceConfigSecret
+      default: "iib-services-config"
+      type: string
+      description: Secret that contains IIB's service configuration
+    - name: iibOverwriteFromIndexCredential
+      default: "iib-overwrite-fromimage-credentials"
+      type: string
+      description: Secret that stores IIB's overwrite_from_index_token parameter value
+    - name: fbcPublishingCredentials
+      type: string
+      default: "fbc-publishing-credentials"
+      description: Secret used to publish the built index image
+    - name: requestUpdateTimeout
+      type: string
+      description: Max seconds to wait until the status is updated
+    - name: buildTimeoutSeconds
+      type: string
+      description: Max seconds to wait until the build finishes
+    - name: verify_ec_task_bundle
+      type: string
+      description: The location of the bundle containing the verify-enterprise-contract task
+  workspaces:
+    - name: release-workspace
+  results:
+    - name: requestMessage
+      value: $(tasks.add-fbc-contribution-to-index-image.results.requestMessage)
+    - name: requestReason
+      value: $(tasks.add-fbc-contribution-to-index-image.results.requestReason)
+  tasks:
+    - name: collect-data
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/collect-data/0.1/collect-data.yaml
+      params:
+        - name: release
+          value: $(params.release)
+        - name: releaseplan
+          value: $(params.releaseplan)
+        - name: releaseplanadmission
+          value: $(params.releaseplanadmission)
+        - name: releasestrategy
+          value: $(params.releasestrategy)
+        - name: snapshot
+          value: $(params.snapshot)
+      workspaces:
+        - name: data
+          workspace: release-workspace
+    - name: verify-enterprise-contract
+      taskRef:
+        resolver: "bundles"
+        params:
+          - name: bundle
+            value: $(params.verify_ec_task_bundle)
+          - name: kind
+            value: task
+          - name: name
+            value: verify-enterprise-contract
+      params:
+        - name: IMAGES
+          value: "$(workspaces.data.path)/snapshot_spec.json"
+        - name: SSL_CERT_DIR
+          value: /var/run/secrets/kubernetes.io/serviceaccount
+        - name: POLICY_CONFIGURATION
+          value: $(params.enterpriseContractPolicy)
+        - name: STRICT
+          value: "1"
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - collect-data
+    - name: add-fbc-contribution-to-index-image
+      workspaces:
+        - name: input
+          workspace: release-workspace
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/create-internal-request/0.6/create-internal-request.yaml
+      params:
+        - name: pipelineRunName
+          value: $(context.pipelineRun.name)
+        - name: request
+          value: "iib"
+        - name: updateGenericResult
+          value: "true"
+        - name: params
+          value:
+            - name: binaryImage
+              value: "$(params.binaryImage)"
+            - name: fromIndex
+              value: "$(params.fromIndex)"
+            - name: buildTags
+              value: "$(params.buildTags)"
+            - name: addArches
+              value: "$(params.addArches)"
+            - name: buildTimeoutSeconds
+              value: "$(params.buildTimeoutSeconds)"
+            - name: iibServiceConfigSecret
+              value: "$(params.iibServiceConfigSecret)"
+            - name: iibOverwriteFromIndexCredential
+              value: "$(params.iibOverwriteFromIndexCredential)"
+            - name: fbcFragment
+              value: "$(tasks.collect-data.results.fbcFragment)"
+      runAfter:
+        - verify-enterprise-contract
+    - name: extract-requester-from-release
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/upstream/tekton/kubernetes-actions/0.2/kubernetes-actions.yaml
+      params:
+        - name: image
+          value: "quay.io/hacbs-release/cloud-builders-kubectl\
+            @sha256:8ab94be8b2b4f3d117f02d868b39540fddd225447abf4014f7ba4765cb39f753"
+        - name: script
+          value: |
+            set -x
+
+            NAMESPACE=$(echo $(params.release) | cut -d '/' -f 1)
+            NAME=$(echo $(params.release) | cut -d '/' -f 2)
+
+            AUTHOR=$(kubectl get release ${NAME} -n ${NAMESPACE} \
+            -o=jsonpath='{.status.attribution.author}' | tee $(results.output-result.path))
+
+            if [[ ${AUTHOR} == "" ]] ; then exit 1 ; fi
+    - name: sign-index-image
+      workspaces:
+        - name: input
+          workspace: release-workspace
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/create-internal-request/0.6/create-internal-request.yaml
+      params:
+        - name: pipelineRunName
+          value: $(context.pipelineRun.name)
+        - name: inputDataFile
+          value: $(tasks.add-fbc-contribution-to-index-image.results.requestResultsFile)
+        - name: request
+          value: "hacbs-signing-pipeline"
+        - name: params
+          value:
+            - name: manifest_digest
+              value: "sharedRequestFile:json:.jsonBuildInfo"
+              jsonKey: ".index_image_resolved"
+            - name: pipeline_image
+              value: "quay.io/redhat-isv/operator-pipelines-images:released"
+            - name: reference
+              value: $(params.targetIndex)
+            - name: requester
+              value: $(tasks.extract-requester-from-release.results.output-result)
+            - name: config_map_name
+              value: $(params.signingConfigMapName)
+      when:
+        - input: "$(tasks.add-fbc-contribution-to-index-image.results.genericResult)"
+          operator: in
+          values: ["fbc_opt_in=true"]
+    - name: publish-index-image
+      workspaces:
+        - name: input
+          workspace: release-workspace
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/create-internal-request/0.6/create-internal-request.yaml
+      params:
+        - name: pipelineRunName
+          value: $(context.pipelineRun.name)
+        - name: inputDataFile
+          value: $(tasks.add-fbc-contribution-to-index-image.results.requestResultsFile)
+        - name: request
+          value: "publish-index-image-pipeline"
+        - name: params
+          value:
+            - name: sourceIndex
+              value: "sharedRequestFile:json:.jsonBuildInfo"
+              jsonKey: ".index_image_resolved"
+            - name: targetIndex
+              value: $(params.targetIndex)
+            - name: publishingCredentials
+              value: $(params.fbcPublishingCredentials)
+            - name: retries
+              value: "0"
+      when:
+        - input: "$(tasks.add-fbc-contribution-to-index-image.results.genericResult)"
+          operator: in
+          values: ["fbc_opt_in=true"]
+      runAfter:
+        - sign-index-image
+  finally:
+    - name: cleanup
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/cleanup-workspace/0.2/cleanup-workspace.yaml
+      params:
+        - name: subdirectory
+          value: "internal-request"
+      workspaces:
+        - name: input
+          workspace: release-workspace

--- a/catalog/pipeline/fbc-release/0.17/samples/sample_release_PipelineRun.yaml
+++ b/catalog/pipeline/fbc-release/0.17/samples/sample_release_PipelineRun.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: fbc-release-run-empty-params
+spec:
+  params:
+    - name: release
+      value: ""
+    - name: releaseplan
+      value: ""
+    - name: releaseplanadmission
+      value: ""
+    - name: releasestrategy
+      value: ""
+    - name: snapshot
+      value: ""
+    - name: enterpriseContractPolicy
+      value: ""
+    - name: release
+      value: ""
+    - name: fromIndex
+      value: ""
+    - name: targetIndex
+      value: ""
+    - name: binaryImage
+      value: ""
+    - name: buildTags
+      value: ""
+    - name: addArches
+      value: ""
+    - name: signingConfigMapName
+      value: ""
+    - name: iibServiceConfigSecret
+      value: ""
+    - name: iibOverwriteFromIndexCredential
+      value: ""
+    - name: fbcPublishingCredentials
+      value: ""
+    - name: requestUpdateTimeout
+      value: ""
+    - name: buildTimeoutSeconds
+      value: ""
+    - name: verify_ec_task_bundle
+      value: ""
+  pipelineRef:
+    resolver: "git"
+    params:
+      - name: url
+        value: https://github.com/redhat-appstudio/release-service-bundles.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: catalog/pipeline/fbc-release/0.17/fbc-release.yaml

--- a/catalog/pipeline/fbc-release/0.17/tests/run.yaml
+++ b/catalog/pipeline/fbc-release/0.17/tests/run.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: fbc-release-run-empty-params
+spec:
+  params:
+    - name: release
+      value: ""
+    - name: releaseplan
+      value: ""
+    - name: releaseplanadmission
+      value: ""
+    - name: releasestrategy
+      value: ""
+    - name: snapshot
+      value: ""
+    - name: enterpriseContractPolicy
+      value: ""
+    - name: release
+      value: ""
+    - name: fromIndex
+      value: ""
+    - name: targetIndex
+      value: ""
+    - name: binaryImage
+      value: ""
+    - name: buildTags
+      value: ""
+    - name: addArches
+      value: ""
+    - name: signingConfigMapName
+      value: ""
+    - name: iibServiceConfigSecret
+      value: ""
+    - name: iibOverwriteFromIndexCredential
+      value: ""
+    - name: fbcPublishingCredentials
+      value: ""
+    - name: requestUpdateTimeout
+      value: ""
+    - name: buildTimeoutSeconds
+      value: ""
+    - name: verify_ec_task_bundle
+      value: ""
+  pipelineRef:
+    resolver: "git"
+    params:
+      - name: url
+        value: https://github.com/redhat-appstudio/release-service-bundles.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: catalog/pipeline/fbc-release/0.17/fbc-release.yaml

--- a/catalog/pipeline/push-to-external-registry/0.14/README.md
+++ b/catalog/pipeline/push-to-external-registry/0.14/README.md
@@ -1,0 +1,82 @@
+# Push to External Registry Pipeline
+
+Tekton pipeline to push images to an external registry.
+
+## Parameters
+
+| Name | Description | Optional | Default value |
+|------|-------------|----------|---------------|
+| release | The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution | No | - |
+| releaseplan | The namespaced name (namespace/name) of the releasePlan | No | - |
+| releaseplanadmission | The namespaced name (namespace/name) of the releasePlanAdmission | No | - |
+| releasestrategy | The namespaced name (namespace/name) of the releaseStrategy | No | - |
+| snapshot | The namespaced name (namespace/name) of the snapshot | No | - |
+| enterpriseContractPolicy | JSON representation of the policy to be applied when validating the enterprise contract | No | - |
+| extraConfigGitUrl |URL to the remote Git repository containing the extra config | No | - |
+| extraConfigGitRevision | Revision to fetch from the remote Git repository containing the extra config | No | - |
+| extraConfigPath | Path to the extra config file within the repository | No | - |
+| tag | The default tag to use when mapping file does not contain a tag | No | - |
+| addGitShaTag | When pushing the snapshot components, also push a tag with the image git sha | Yes | true |
+| addSourceShaTag | When pushing the snapshot components, also push a tag with the image source sha | Yes | true |
+| addTimestampTag | When pushing the snapshot components, also push a tag with the current timestamp | Yes | false |
+| pyxisServerType | The Pyxis server type to use. Options are 'production' and 'stage' | No | - |
+| pyxisSecret | The kubernetes secret to use to authenticate to Pyxis. It needs to contain two keys: key and cert | No | - |
+| postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
+| verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
+
+## Changes since 0.13
+* git resolvers are used in place of release bundle resolvers
+
+## Changes since 0.12
+* the push-snapshot task was updated to version 0.9 to use `cosign copy` instead of `skopeo copy`
+
+## Changes since 0.11
+* the collect-data task was added
+  * this includes adding the required parameters release, releaseplan, releaseplanadmission,
+      and releasestrategy as pipeline parameters
+* the snapshot parameter is now a namespaced name instead of a JSON string
+  * task versions were updated in accordance with this change
+
+## Changes since 0.10
+* the verify_ec_task_bundle parameter was added
+  * with this addition, the verify-enterprise-contract task version is no longer static
+
+## Changes since 0.9
+* addGitShaTag now defaults to true instead of false
+
+## Changes since 0.8
+* Use version 0.4 of apply-mapping task and set the new failOnEmptyResult parameter to true
+  * This will ensure that if the result of mapping is an empty component list, the task will fail
+
+## Changes since 0.7
+* Upgrade push-snapshot task to version 0.7
+  * Only the first 7 characters are used for the git sha tag in Quay.
+
+## Changes since 0.6
+Add `push-sbom-to-pyxis` task to the pipeline. This will ensure that sbom components
+for the image are pushed to Pyxis as part of this pipeline.
+
+## Changes since 0.5
+The syntax for `taskRef.bundle` and `pipelineRef.bundle` is deprecated,
+bundles resolver is used with new format.
+
+## Changes since 0.4
+* Upgrade push-snapshot task to version 0.6
+  * addShaTag parameter is now named addSourceShaTag
+  * addGitShaTag parameter is now supported and passed as a pipeline parameter to the task
+
+## Changes since 0.3
+
+* Upgrade push-snapshot task to version 0.5
+  * addShaTag parameter is now supported and passed as a pipeline parameter to the task
+  * addTimestampTag parameter is now supported and passed as a pipeline parameter to the task
+
+## Changes since 0.2
+
+* push-snapshot now supports tag parameter
+
+## Changes since 0.1
+
+* Upgrade create-pyxis-image task to version 0.2
+  * correct incorrect snapshot param
+

--- a/catalog/pipeline/push-to-external-registry/0.14/push-to-external-registry.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.14/push-to-external-registry.yaml
@@ -1,0 +1,263 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: push-to-external-registry
+  labels:
+    app.kubernetes.io/version: "0.14"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Tekton pipeline to release HACBS Snapshot to Quay
+  params:
+    - name: release
+      type: string
+      description:
+        The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution
+    - name: releaseplan
+      type: string
+      description: The namespaced name (namespace/name) of the releasePlan
+    - name: releaseplanadmission
+      type: string
+      description: The namespaced name (namespace/name) of the releasePlanAdmission
+    - name: releasestrategy
+      type: string
+      description: The namespaced name (namespace/name) of the releaseStrategy
+    - name: snapshot
+      type: string
+      description: The namespaced name (namespace/name) of the snapshot
+    - name: enterpriseContractPolicy
+      type: string
+      description: JSON representation of the EnterpriseContractPolicy
+    - name: extraConfigGitUrl
+      type: string
+      description: URL to the remote Git repository containing the extra config
+      default: ""
+    - name: extraConfigGitRevision
+      type: string
+      description: Revision to fetch from the remote Git repository containing the extra config
+      default: ""
+    - name: extraConfigPath
+      type: string
+      description: Path to the extra config file within the repository
+      default: ""
+    - name: tag
+      type: string
+      description: The default tag to use when mapping file does not contain a tag
+    - name: addGitShaTag
+      type: string
+      description: When pushing the snapshot components, also push a tag with the image git sha
+      default: "true"
+    - name: addSourceShaTag
+      type: string
+      description: When pushing the snapshot components, also push a tag with the image source sha
+      default: "true"
+    - name: addTimestampTag
+      type: string
+      description: When pushing the snapshot components, also push a tag with the current timestamp
+      default: "false"
+    - name: pyxisServerType
+      type: string
+      description: The Pyxis server type to use. Options are 'production' and 'stage'
+    - name: pyxisSecret
+      type: string
+      description: |
+        The kubernetes secret to use to authenticate to Pyxis. It needs to contain two keys: key and cert
+    - name: postCleanUp
+      type: string
+      description: Cleans up workspace after finishing executing the pipeline
+      default: "true"
+    - name: verify_ec_task_bundle
+      type: string
+      description: The location of the bundle containing the verify-enterprise-contract task
+  workspaces:
+    - name: release-workspace
+  tasks:
+    - name: collect-data
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/collect-data/0.1/collect-data.yaml
+      params:
+        - name: release
+          value: $(params.release)
+        - name: releaseplan
+          value: $(params.releaseplan)
+        - name: releaseplanadmission
+          value: $(params.releaseplanadmission)
+        - name: releasestrategy
+          value: $(params.releasestrategy)
+        - name: snapshot
+          value: $(params.snapshot)
+      workspaces:
+        - name: data
+          workspace: release-workspace
+    - name: clone-config-file
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/build-definitions.git
+          - name: revision
+            value: dedce1f59906394ea777606683eec9eb2de465ac
+          - name: pathInRepo
+            value: task/git-clone/0.1/git-clone.yaml
+      when:
+        - input: $(params.extraConfigGitUrl)
+          operator: notin
+          values: [""]
+      params:
+        - name: url
+          value: $(params.extraConfigGitUrl)
+        - name: revision
+          value: $(params.extraConfigGitRevision)
+        - name: subdirectory
+          value: "$(context.pipelineRun.uid)"
+      workspaces:
+        - name: output
+          workspace: release-workspace
+    - name: apply-mapping
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/apply-mapping/0.5/apply-mapping.yaml
+      params:
+        - name: extraConfigPath
+          value: "$(context.pipelineRun.uid)/$(params.extraConfigPath)"
+        - name: failOnEmptyResult
+          value: "true"
+      when:
+        - input: $(tasks.clone-config-file.results.commit)
+          operator: notin
+          values: [""]
+      workspaces:
+        - name: config
+          workspace: release-workspace
+      runAfter:
+        - collect-data
+    - name: verify-enterprise-contract
+      taskRef:
+        resolver: "bundles"
+        params:
+          - name: bundle
+            value: $(params.verify_ec_task_bundle)
+          - name: kind
+            value: task
+          - name: name
+            value: verify-enterprise-contract
+      params:
+        - name: IMAGES
+          value: "$(workspaces.data.path)/mapped_snapshot.json"
+        - name: SSL_CERT_DIR
+          value: /var/run/secrets/kubernetes.io/serviceaccount
+        - name: POLICY_CONFIGURATION
+          value: $(params.enterpriseContractPolicy)
+        - name: STRICT
+          value: "1"
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - apply-mapping
+    - name: push-snapshot
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/push-snapshot/0.9/push-snapshot.yaml
+      params:
+        - name: tag
+          value: $(params.tag)
+        - name: addGitShaTag
+          value: $(params.addGitShaTag)
+        - name: addSourceShaTag
+          value: $(params.addSourceShaTag)
+        - name: addTimestampTag
+          value: $(params.addTimestampTag)
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - verify-enterprise-contract
+    - name: create-pyxis-image
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/create-pyxis-image/0.4/create-pyxis-image.yaml
+      params:
+        - name: server
+          value: $(params.pyxisServerType)
+        - name: pyxisSecret
+          value: $(params.pyxisSecret)
+        - name: tag
+          value: $(params.tag)
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - push-snapshot
+    - name: push-sbom-to-pyxis
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/push-sbom-to-pyxis/0.2/push-sbom-to-pyxis.yaml
+      params:
+        - name: containerImageIDs
+          value: $(tasks.create-pyxis-image.results.containerImageIDs)
+        - name: server
+          value: $(params.pyxisServerType)
+        - name: pyxisSecret
+          value: $(params.pyxisSecret)
+      workspaces:
+        - name: data
+          workspace: release-workspace
+  finally:
+    - name: cleanup
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/cleanup-workspace/0.2/cleanup-workspace.yaml
+      when:
+        - input: $(params.postCleanUp)
+          operator: in
+          values: ["true"]
+        - input: $(params.extraConfigGitUrl)
+          operator: notin
+          values: [""]
+      params:
+        - name: subdirectory
+          value: "$(context.pipelineRun.uid)"
+      workspaces:
+        - name: input
+          workspace: release-workspace

--- a/catalog/pipeline/push-to-external-registry/0.14/samples/sample_push-to-external-registry_PipelineRun.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.14/samples/sample_push-to-external-registry_PipelineRun.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: push-to-external-registry-run-empty-params
+spec:
+  params:
+    - name: release
+      value: ""
+    - name: releaseplan
+      value: ""
+    - name: releaseplanadmission
+      value: ""
+    - name: releasestrategy
+      value: ""
+    - name: snapshot
+      value: ""
+    - name: enterpriseContractPolicy
+      value: ""
+    - name: extraConfigGitUrl
+      value: ""
+    - name: extraConfigGitRevision
+      value: ""
+    - name: extraConfigPath
+      value: ""
+    - name: pyxisServerType
+      value: ""
+    - name: pyxisSecret
+      value: ""
+    - name: tag
+      value: ""
+    - name: postCleanUp
+      value: ""
+    - name: verify_ec_task_bundle
+      value: ""
+  pipelineRef:
+    resolver: "git"
+    params:
+      - name: url
+        value: https://github.com/redhat-appstudio/release-service-bundles.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: catalog/pipeline/push-to-external-registry/0.14/push-to-external-registry.yaml

--- a/catalog/pipeline/push-to-external-registry/0.14/tests/run.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.14/tests/run.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: push-to-external-registry-run-empty-params
+spec:
+  params:
+    - name: release
+      value: ""
+    - name: releaseplan
+      value: ""
+    - name: releaseplanadmission
+      value: ""
+    - name: releasestrategy
+      value: ""
+    - name: snapshot
+      value: ""
+    - name: enterpriseContractPolicy
+      value: ""
+    - name: extraConfigGitUrl
+      value: ""
+    - name: extraConfigGitRevision
+      value: ""
+    - name: extraConfigPath
+      value: ""
+    - name: pyxisServerType
+      value: ""
+    - name: pyxisSecret
+      value: ""
+    - name: tag
+      value: ""
+    - name: postCleanUp
+      value: ""
+    - name: verify_ec_task_bundle
+      value: ""
+  pipelineRef:
+    resolver: "git"
+    params:
+      - name: url
+        value: https://github.com/redhat-appstudio/release-service-bundles.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: catalog/pipeline/push-to-external-registry/0.14/push-to-external-registry.yaml

--- a/catalog/pipeline/release/0.17/README.md
+++ b/catalog/pipeline/release/0.17/README.md
@@ -1,0 +1,120 @@
+# Release Pipeline
+
+Tekton pipeline to release Stonesoup Snapshot to Quay.
+
+## Parameters
+
+| Name | Description | Optional | Default value |
+|------|-------------|----------|---------------|
+| release | The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution | No | - |
+| releaseplan | The namespaced name (namespace/name) of the releasePlan | No | - |
+| releaseplanadmission | The namespaced name (namespace/name) of the releasePlanAdmission | No | - |
+| releasestrategy | The namespaced name (namespace/name) of the releaseStrategy | No | - |
+| snapshot | The namespaced name (namespace/name) of the snapshot | No | - |
+| enterpriseContractPolicy | JSON representation of the policy to be applied when validating the enterprise contract | No | - |
+| extraConfigGitUrl |URL to the remote Git repository containing the extra config | No | - |
+| extraConfigGitRevision | Revision to fetch from the remote Git repository containing the extra config | No | - |
+| extraConfigPath | Path to the extra config file within the repository | No | - |
+| addGitShaTag | When pushing the snapshot components, also push a tag with the image git sha | Yes | true |
+| postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
+| verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
+
+## Changes since 0.16
+* git resolvers are used in place of release bundle resolvers
+
+## Changes since 0.15
+* the push-snapshot task was updated to version 0.9 to use `cosign copy` instead of `skopeo copy`
+
+## Changes since 0.14
+* the collect-data task was added
+  * this includes adding the required parameters release, releaseplan, releaseplanadmission,
+      and releasestrategy as pipeline parameters
+* the snapshot parameter is now a namespaced name instead of a JSON string
+  * task versions were updated in accordance with this change
+
+## Changes since 0.13
+* the verify_ec_task_bundle parameter was added
+  * with this addition, the verify-enterprise-contract task version is no longer static
+
+## Changes since 0.12
+* addGitShaTag now defaults to true instead of false
+
+## Changes since 0.11
+* Use version 0.4 of apply-mapping task and set the new failOnEmptyResult parameter to true
+  * This will ensure that if the result of mapping is an empty component list, the task will fail
+
+## Changes since 0.10
+
+Update tag of ec-task-bundle task
+
+## Changes since 0.9
+
+* The syntax for `taskRef.bundle` and `pipelineRef.bundle` is deprecated,
+bundles resolver is used with new format.
+* Upgrade push-snapshot task for v0.6 parameter
+  * addGitShaTag parameter is now supported and passed as a pipeline parameter to the task with value false
+
+## Changes since 0.8
+
+Update tag of ec-task-bundle task
+
+## Changes since 0.7
+
+Pipeline name was changed:
+* metadata.name = `release`
+
+## Changes since 0.6
+
+Pipeline definition was changed:
+* Task `verify-enterprise-contract` now uses the param `STRICT: 1`
+
+## Changes since 0.5
+
+Pipeline definition was changed:
+* Taskref renamed from `verify-enterprise-contract-v2` to `verify-enterprise-contract`
+* Taskref `verify-enterprise-contract` points to new bundle location.
+
+## Changes since 0.4
+
+ Pipeline definition was changed:
+  * Task `apply-mapping` was replaced with `task-apply-mapping`
+  * Task `cleanup-workspace` was replaced with `task-cleanup-workspace`
+
+## Changes since 0.3 (milestone-8)
+
+ Pipeline definition was changed:
+  * Parameter `applicationSnapshot` was changed to `snapshot`
+  * Task `apply-mapping` was changed
+    * Task parameter `applicationSnapshot` value was changed
+      * old: $(params.applicationSnapshot)
+      * new: $(params.snapshot)
+  * Task `prepare-validation` was changed
+    * Task parameter `applicationSnapshot` value was changed
+      * old: $(params.applicationSnapshot)
+      * new: $(params.snapshot)
+  * Task `push-application-snapshot` was changed
+    * Task parameter `mappedApplicationSnapshot` value was changed
+      * old: $(params.mappedApplicationSnapshot)
+      * new: $(params.mappedSnapshot)
+
+## Changes since 0.2 (milestone-6)
+
+* Pipeline definition was changed:
+  * Parameter `policy` was changed to `enterpriseContractPolicy`
+  * Task `verify-enterprise-contract` was changed
+    * Task parameter `POLICY_CONFIGURATION` value was changed
+      * old: $(params.policy)
+      * new: $(params.enterpriseContractPolicy)
+
+## Changes since 0.1 (milestone-5)
+
+* Enterprise Contract task was changed:
+  * Task `prepare-validation` was removed
+  * Task `verify-enterprise-contract` was replaced
+    * old: quay.io/hacbs-release/verify-enterprise-contract:main
+    * new: quay.io/hacbs-release/verify-enterprise-contract-v2:main
+    * Task Parameter `snapshot` was removed
+    * Task parameter `IMAGES` was added
+    * Task Parameter `STRICT` was added
+    * Task Parameter `IMAGE_REF` was removed
+    * Task Parameter `REKOR_HOST` was removed

--- a/catalog/pipeline/release/0.17/release.yaml
+++ b/catalog/pipeline/release/0.17/release.yaml
@@ -1,0 +1,197 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: release
+  labels:
+    app.kubernetes.io/version: "0.17"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Tekton pipeline to release HACBS Snapshot to Quay
+  params:
+    - name: release
+      type: string
+      description:
+        The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution
+    - name: releaseplan
+      type: string
+      description: The namespaced name (namespace/name) of the releasePlan
+    - name: releaseplanadmission
+      type: string
+      description: The namespaced name (namespace/name) of the releasePlanAdmission
+    - name: releasestrategy
+      type: string
+      description: The namespaced name (namespace/name) of the releaseStrategy
+    - name: snapshot
+      type: string
+      description: The namespaced name (namespace/name) of the snapshot
+    - name: enterpriseContractPolicy
+      type: string
+      description: JSON representation of the EnterpriseContractPolicy
+    - name: extraConfigGitUrl
+      type: string
+      description: URL to the remote Git repository containing the extra config
+      default: ""
+    - name: extraConfigGitRevision
+      type: string
+      description: Revision to fetch from the remote Git repository containing the extra config
+      default: ""
+    - name: extraConfigPath
+      type: string
+      description: Path to the extra config file within the repository
+      default: ""
+    - name: addGitShaTag
+      type: string
+      description: When pushing the snapshot components, also push a tag with the image git sha
+      default: "true"
+    - name: postCleanUp
+      type: string
+      description: Cleans up workspace after finishing executing the pipeline
+      default: "true"
+    - name: verify_ec_task_bundle
+      type: string
+      description: The location of the bundle containing the verify-enterprise-contract task
+  workspaces:
+    - name: release-workspace
+  tasks:
+    - name: collect-data
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/collect-data/0.1/collect-data.yaml
+      params:
+        - name: release
+          value: $(params.release)
+        - name: releaseplan
+          value: $(params.releaseplan)
+        - name: releaseplanadmission
+          value: $(params.releaseplanadmission)
+        - name: releasestrategy
+          value: $(params.releasestrategy)
+        - name: snapshot
+          value: $(params.snapshot)
+      workspaces:
+        - name: data
+          workspace: release-workspace
+    - name: clone-config-file
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/build-definitions.git
+          - name: revision
+            value: dedce1f59906394ea777606683eec9eb2de465ac
+          - name: pathInRepo
+            value: task/git-clone/0.1/git-clone.yaml
+      when:
+        - input: $(params.extraConfigGitUrl)
+          operator: notin
+          values: [""]
+      params:
+        - name: url
+          value: $(params.extraConfigGitUrl)
+        - name: revision
+          value: $(params.extraConfigGitRevision)
+        - name: subdirectory
+          value: "$(context.pipelineRun.uid)"
+      workspaces:
+        - name: output
+          workspace: release-workspace
+    - name: apply-mapping
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/apply-mapping/0.5/apply-mapping.yaml
+      params:
+        - name: extraConfigPath
+          value: "$(context.pipelineRun.uid)/$(params.extraConfigPath)"
+        - name: failOnEmptyResult
+          value: "true"
+      when:
+        - input: $(tasks.clone-config-file.results.commit)
+          operator: notin
+          values: [""]
+      workspaces:
+        - name: config
+          workspace: release-workspace
+      runAfter:
+        - collect-data
+    - name: verify-enterprise-contract
+      taskRef:
+        resolver: "bundles"
+        params:
+          - name: bundle
+            value: $(params.verify_ec_task_bundle)
+          - name: kind
+            value: task
+          - name: name
+            value: verify-enterprise-contract
+      params:
+        - name: IMAGES
+          value: "$(workspaces.data.path)/mapped_snapshot.json"
+        - name: SSL_CERT_DIR
+          value: /var/run/secrets/kubernetes.io/serviceaccount
+        - name: POLICY_CONFIGURATION
+          value: $(params.enterpriseContractPolicy)
+        - name: STRICT
+          value: "1"
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - apply-mapping
+    - name: push-snapshot
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/push-snapshot/0.9/push-snapshot.yaml
+      params:
+        - name: addGitShaTag
+          value: $(params.addGitShaTag)
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - verify-enterprise-contract
+  finally:
+    - name: cleanup
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/cleanup-workspace/0.2/cleanup-workspace.yaml
+      when:
+        - input: $(params.postCleanUp)
+          operator: in
+          values: ["true"]
+        - input: $(params.extraConfigGitUrl)
+          operator: notin
+          values: [""]
+      params:
+        - name: subdirectory
+          value: "$(context.pipelineRun.uid)"
+      workspaces:
+        - name: input
+          workspace: release-workspace

--- a/catalog/pipeline/release/0.17/samples/sample_release_PipelineRun.yaml
+++ b/catalog/pipeline/release/0.17/samples/sample_release_PipelineRun.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: release-run-empty-params
+spec:
+  params:
+    - name: release
+      value: ""
+    - name: releaseplan
+      value: ""
+    - name: releaseplanadmission
+      value: ""
+    - name: releasestrategy
+      value: ""
+    - name: snapshot
+      value: ""
+    - name: enterpriseContractPolicy
+      value: ""
+    - name: extraConfigGitUrl
+      value: ""
+    - name: extraConfigGitRevision
+      value: ""
+    - name: extraConfigPath
+      value: ""
+    - name: postCleanUp
+      value: ""
+    - name: verify_ec_task_bundle
+      value: ""
+  pipelineRef:
+    resolver: "git"
+    params:
+      - name: url
+        value: https://github.com/redhat-appstudio/release-service-bundles.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: catalog/pipeline/release/0.17/release.yaml

--- a/catalog/pipeline/release/0.17/tests/run.yaml
+++ b/catalog/pipeline/release/0.17/tests/run.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: release-run-empty-params
+spec:
+  params:
+    - name: release
+      value: ""
+    - name: releaseplan
+      value: ""
+    - name: releaseplanadmission
+      value: ""
+    - name: releasestrategy
+      value: ""
+    - name: snapshot
+      value: ""
+    - name: enterpriseContractPolicy
+      value: ""
+    - name: extraConfigGitUrl
+      value: ""
+    - name: extraConfigGitRevision
+      value: ""
+    - name: extraConfigPath
+      value: ""
+    - name: postCleanUp
+      value: ""
+    - name: verify_ec_task_bundle
+      value: ""
+  pipelineRef:
+    resolver: "git"
+    params:
+      - name: url
+        value: https://github.com/redhat-appstudio/release-service-bundles.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: catalog/pipeline/release/0.17/release.yaml

--- a/catalog/task/apply-mapping/0.5/samples/sample_apply-mapping_TaskRun.yaml
+++ b/catalog/task/apply-mapping/0.5/samples/sample_apply-mapping_TaskRun.yaml
@@ -5,11 +5,11 @@ metadata:
   name: apply-mapping-run-empty-params
 spec:
   taskRef:
-    resolver: "bundles"
+    resolver: "git"
     params:
-      - name: bundle
-        value: quay.io/hacbs-release/task-apply-mapping:0.5
-      - name: kind
-        value: task
-      - name: name
-        value: apply-mapping
+      - name: url
+        value: https://github.com/redhat-appstudio/release-service-bundles.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: catalog/task/apply-mapping/0.5/apply-mapping.yaml

--- a/catalog/task/cleanup-workspace/0.2/samples/sample_cleanup-workspace_TaskRun.yaml
+++ b/catalog/task/cleanup-workspace/0.2/samples/sample_cleanup-workspace_TaskRun.yaml
@@ -8,11 +8,11 @@ spec:
     - name: subdirectory
       value: ""
   taskRef:
-    resolver: "bundles"
+    resolver: "git"
     params:
-      - name: bundle
-        value: quay.io/hacbs-release/task-cleanup-workspace:0.2
-      - name: kind
-        value: task
-      - name: name
-        value: cleanup-workspace
+      - name: url
+        value: https://github.com/redhat-appstudio/release-service-bundles.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: catalog/task/cleanup-workspace/0.2/cleanup-workspace.yaml

--- a/catalog/task/collect-data/0.1/samples/sample_collect-extra-data_TaskRun.yaml
+++ b/catalog/task/collect-data/0.1/samples/sample_collect-extra-data_TaskRun.yaml
@@ -16,11 +16,11 @@ spec:
     - name: snapshot
       value: "default/snapshot"
   taskRef:
-    resolver: "bundles"
+    resolver: "git"
     params:
-      - name: bundle
-        value: quay.io/hacbs-release/task-collect-data:0.1
-      - name: kind
-        value: task
-      - name: name
-        value: collect-data
+      - name: url
+        value: https://github.com/redhat-appstudio/release-service-bundles.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: catalog/task/collect-data/0.1/collect-data.yaml

--- a/catalog/task/create-internal-request/0.6/samples/sample_create-internal-request_TaskRun.yaml
+++ b/catalog/task/create-internal-request/0.6/samples/sample_create-internal-request_TaskRun.yaml
@@ -14,5 +14,11 @@ spec:
     - name: inputDataFile
       value: ""
   taskRef:
-    name: create-internal-request
-    bundle: quay.io/hacbs-release/task-create-internal-request:0.6
+    resolver: "git"
+    params:
+      - name: url
+        value: https://github.com/redhat-appstudio/release-service-bundles.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: catalog/task/create-internal-request/0.6/create-internal-request.yaml

--- a/catalog/task/create-internal-request/0.6/tests/run.yaml
+++ b/catalog/task/create-internal-request/0.6/tests/run.yaml
@@ -14,5 +14,11 @@ spec:
     - name: inputDataFile
       value: ""
   taskRef:
-    name: create-internal-request
-    bundle: quay.io/hacbs-release/task-create-internal-request:0.6
+    resolver: "git"
+    params:
+      - name: url
+        value: https://github.com/redhat-appstudio/release-service-bundles.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: catalog/task/create-internal-request/0.6/create-internal-request.yaml

--- a/catalog/task/create-pyxis-image/0.4/samples/sample_create-pyxis-image_TaskRun.yaml
+++ b/catalog/task/create-pyxis-image/0.4/samples/sample_create-pyxis-image_TaskRun.yaml
@@ -10,11 +10,11 @@ spec:
     - name: tag
       value: ""
   taskRef:
-    resolver: "bundles"
+    resolver: "git"
     params:
-      - name: bundle
-        value: quay.io/hacbs-release/task-create-pyxis-image:0.4
-      - name: kind
-        value: task
-      - name: name
-        value: create-pyxis-image
+      - name: url
+        value: https://github.com/redhat-appstudio/release-service-bundles.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: catalog/task/create-pyxis-image/0.4/create-pyxis-image.yaml

--- a/catalog/task/create-pyxis-image/0.4/tests/run.yaml
+++ b/catalog/task/create-pyxis-image/0.4/tests/run.yaml
@@ -10,11 +10,11 @@ spec:
     - name: tag
       value: ""
   taskRef:
-    resolver: "bundles"
+    resolver: "git"
     params:
-      - name: bundle
-        value: quay.io/hacbs-release/task-create-pyxis-image:0.4
-      - name: kind
-        value: task
-      - name: name
-        value: create-pyxis-image
+      - name: url
+        value: https://github.com/redhat-appstudio/release-service-bundles.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: catalog/task/create-pyxis-image/0.4/create-pyxis-image.yaml

--- a/catalog/task/get-ocp-version/0.1/samples/sample_get-ocp-version_TaskRun.yaml
+++ b/catalog/task/get-ocp-version/0.1/samples/sample_get-ocp-version_TaskRun.yaml
@@ -8,11 +8,11 @@ spec:
     - name: fbcFragment
       value: ""
   taskRef:
-    resolver: "bundles"
+    resolver: "git"
     params:
-      - name: bundle
-        value: quay.io/hacbs-release/task-get-ocp-version:0.1
-      - name: kind
-        value: task
-      - name: name
-        value: get-ocp-version
+      - name: url
+        value: https://github.com/redhat-appstudio/release-service-bundles.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: catalog/task/get-ocp-version/0.1/get-ocp-version.yaml

--- a/catalog/task/prepare-validation/0.3/samples/sample_prepare-validation_TaskRun.yaml
+++ b/catalog/task/prepare-validation/0.3/samples/sample_prepare-validation_TaskRun.yaml
@@ -8,11 +8,11 @@ spec:
     - name: snapshot
       value: ""
   taskRef:
-    resolver: "bundles"
+    resolver: "git"
     params:
-      - name: bundle
-        value: quay.io/hacbs-release/task-prepare-validation:0.3
-      - name: kind
-        value: task
-      - name: name
-        value: prepare-validation
+      - name: url
+        value: https://github.com/redhat-appstudio/release-service-bundles.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: catalog/task/prepare-validation/0.3/prepare-validation.yaml

--- a/catalog/task/prepare-validation/0.3/tests/run.yaml
+++ b/catalog/task/prepare-validation/0.3/tests/run.yaml
@@ -8,11 +8,11 @@ spec:
     - name: snapshot
       value: ""
   taskRef:
-    resolver: "bundles"
+    resolver: "git"
     params:
-      - name: bundle
-        value: quay.io/hacbs-release/task-prepare-validation:0.3
-      - name: kind
-        value: task
-      - name: name
-        value: prepare-validation
+      - name: url
+        value: https://github.com/redhat-appstudio/release-service-bundles.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: catalog/task/prepare-validation/0.3/prepare-validation.yaml

--- a/catalog/task/publish-index-image/0.2/samples/publish-index-image_TaskRun.yaml
+++ b/catalog/task/publish-index-image/0.2/samples/publish-index-image_TaskRun.yaml
@@ -10,11 +10,11 @@ spec:
     - name: targetIndex
       value: ""
   taskRef:
-    resolver: "bundles"
+    resolver: "git"
     params:
-      - name: bundle
-        value: quay.io/hacbs-release/task-publish-index-image:0.1
-      - name: kind
-        value: task
-      - name: name
-        value: publish-index-image
+      - name: url
+        value: https://github.com/redhat-appstudio/release-service-bundles.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: catalog/task/publish-index-image/0.2/publish-index-image.yaml

--- a/catalog/task/publish-index-image/0.2/tests/run.yaml
+++ b/catalog/task/publish-index-image/0.2/tests/run.yaml
@@ -10,11 +10,11 @@ spec:
     - name: targetIndex
       value: ""
   taskRef:
-    resolver: "bundles"
+    resolver: "git"
     params:
-      - name: bundle
-        value: quay.io/hacbs-release/task-publish-index-image:0.1
-      - name: kind
-        value: task
-      - name: name
-        value: publish-index-image
+      - name: url
+        value: https://github.com/redhat-appstudio/release-service-bundles.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: catalog/task/publish-index-image/0.2/publish-index-image.yaml

--- a/catalog/task/push-sbom-to-pyxis/0.2/sample/sample_push-sbom-to-pyxis_TaskRun.yaml
+++ b/catalog/task/push-sbom-to-pyxis/0.2/sample/sample_push-sbom-to-pyxis_TaskRun.yaml
@@ -10,11 +10,11 @@ spec:
     - name: pyxisSecret
       value: ""
   taskRef:
-    resolver: "bundles"
+    resolver: "git"
     params:
-      - name: bundle
-        value: quay.io/hacbs-release/task-push-sbom-to-pyxis:0.2
-      - name: kind
-        value: task
-      - name: name
-        value: push-sbom-to-pyxis
+      - name: url
+        value: https://github.com/redhat-appstudio/release-service-bundles.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: catalog/task/push-sbom-to-pyxis/0.2/push-sbom-to-pyxis.yaml

--- a/catalog/task/push-sbom-to-pyxis/0.2/tests/run.yaml
+++ b/catalog/task/push-sbom-to-pyxis/0.2/tests/run.yaml
@@ -10,11 +10,11 @@ spec:
     - name: pyxisSecret
       value: ""
   taskRef:
-    resolver: "bundles"
+    resolver: "git"
     params:
-      - name: bundle
-        value: quay.io/hacbs-release/task-push-sbom-to-pyxis:0.2
-      - name: kind
-        value: task
-      - name: name
-        value: push-sbom-to-pyxis
+      - name: url
+        value: https://github.com/redhat-appstudio/release-service-bundles.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: catalog/task/push-sbom-to-pyxis/0.2/push-sbom-to-pyxis.yaml

--- a/catalog/task/push-snapshot/0.9/samples/sample_push-snapshot_TaskRun.yaml
+++ b/catalog/task/push-snapshot/0.9/samples/sample_push-snapshot_TaskRun.yaml
@@ -8,11 +8,11 @@ spec:
     - name: tag
       value: "test"
   taskRef:
-    resolver: "bundles"
+    resolver: "git"
     params:
-      - name: bundle
-        value: quay.io/hacbs-release/task-push-snapshot:0.9
-      - name: kind
-        value: task
-      - name: name
-        value: push-snapshot
+      - name: url
+        value: https://github.com/redhat-appstudio/release-service-bundles.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: catalog/task/push-snapshot/0.9/push-snapshot.yaml

--- a/catalog/task/push-snapshot/0.9/tests/run.yaml
+++ b/catalog/task/push-snapshot/0.9/tests/run.yaml
@@ -8,11 +8,11 @@ spec:
     - name: tag
       value: "test"
   taskRef:
-    resolver: "bundles"
+    resolver: "git"
     params:
-      - name: bundle
-        value: quay.io/hacbs-release/task-push-snapshot:0.9
-      - name: kind
-        value: task
-      - name: name
-        value: push-snapshot
+      - name: url
+        value: https://github.com/redhat-appstudio/release-service-bundles.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: catalog/task/push-snapshot/0.9/push-snapshot.yaml

--- a/catalog/task/sign-index-image/0.1/tests/run.yaml
+++ b/catalog/task/sign-index-image/0.1/tests/run.yaml
@@ -18,11 +18,11 @@ spec:
     - name: pipelineRunName
       value: ""
   taskRef:
-    resolver: "bundles"
+    resolver: "git"
     params:
-      - name: bundle
-        value: quay.io/hacbs-release/task-sign-index-image:0.1
-      - name: kind
-        value: task
-      - name: name
-        value: sign-index-image
+      - name: url
+        value: https://github.com/redhat-appstudio/release-service-bundles.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: catalog/task/sign-index-image/0.1/sign-index-image.yaml


### PR DESCRIPTION
This commit changes the sample for the latest version of each task to use the tekton git resolver instead of the bundle resolvers. It also creates a new version of each pipeline that calls its tasks with git resolvers instead of bundle resolvers. Tasks that are not stored in this repository were left unchanged to be called via bundle resolvers.