### PR TITLE
fix(RHTAPBUGS-560): add subdirectory parameter to tasks

### DIFF
--- a/catalog/task/apply-mapping/0.6/README.md
+++ b/catalog/task/apply-mapping/0.6/README.md
@@ -18,6 +18,12 @@ meant to inform whether a mapped Snapshot is being returned or the original one.
 | extraConfigPath | The path to the config file containing the mapping | Yes | - |
 | failOnEmptyResult | Fail the task if the resulting snapshot contains zero components | Yes | false |
 
+## Changes since 0.5
+  * Instead of saving the mapped json to a new file, override the original snapshot spec file
+    * We never really use the original after the mapping anyway and this way we can continue to use the path to the snapshot
+      that we already know in other tasks of the pipeline (at the moment the mapped json file is hardcoded in other places
+      of the pipeline that use it).
+
 ## Changes since 0.4
   * The snapshot parameter was replaced with the snapshotPath parameter
     * The snapshot is now provided via the workspace instead of directly as a parameter

--- a/catalog/task/apply-mapping/0.6/README.md
+++ b/catalog/task/apply-mapping/0.6/README.md
@@ -1,0 +1,42 @@
+# apply-mapping
+
+Tekton task to apply a mapping to an Snapshot.
+
+The purpose of this task is to merge a mapping with the components contained in an Snapshot.
+The mapping is expected to be present in the passed `extraConfigPath`. If the file is not found or
+the file contains no `mapping` key, the original Snapshot is returned. If there is a
+`mapping` key, it is merged with the `components` key in the Snapshot based on component name.
+
+A `mapped` result is also returned from this task containing a simple true/false value that is
+meant to inform whether a mapped Snapshot is being returned or the original one.
+
+## Parameters
+
+| Name | Description | Optional | Default value |
+|------|-------------|----------|---------------|
+| snapshotPath | Path to the JSON string of the Snapshot spec in the config workspace to apply the mapping to | Yes | snapshot_spec.json |
+| extraConfigPath | The path to the config file containing the mapping | Yes | - |
+| failOnEmptyResult | Fail the task if the resulting snapshot contains zero components | Yes | false |
+
+## Changes since 0.4
+  * The snapshot parameter was replaced with the snapshotPath parameter
+    * The snapshot is now provided via the workspace instead of directly as a parameter
+    * The mapped snapshot is now stored in a `mapped_snapshot.json` file in the workspace instead of as a task result
+
+## Changes since 0.3
+
+  * New optional parameter `failOnEmptyResult` was added. When enabled, the task
+    will fail if the resulting snapshot contains 0 components.
+
+## Changes since 0.2
+
+  * Base image was changed from `release-utils` to `release-base-image`
+  * The syntax for `taskRef.bundle` and `pipelineRef.bundle` is deprecated,
+  bundles resolver is used with new format.
+
+## Changes since 0.1 (milestone-8)
+
+  * Task `apply-mapping` was changed
+    * Task parameter `applicationSnapshot` value was changed
+      * old: $(params.applicationSnapshot)
+      * new: $(params.snapshot)

--- a/catalog/task/apply-mapping/0.6/apply-mapping.yaml
+++ b/catalog/task/apply-mapping/0.6/apply-mapping.yaml
@@ -4,13 +4,13 @@ kind: Task
 metadata:
   name: apply-mapping
   labels:
-    app.kubernetes.io/version: "0.5"
+    app.kubernetes.io/version: "0.6"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
 spec:
   description: >-
-    Tekton task to apply a mapping to a Snapshot
+    Tekton task to apply a mapping to a Snapshot. It will override the Snapshot file.
   params:
     - name: snapshotPath
       type: string
@@ -39,13 +39,14 @@ spec:
         set -eux
 
         SNAPSHOT_SPEC_FILE="$(workspaces.config.path)/$(params.snapshotPath)"
+        SNAPSHOT_SPEC_FILE_ORIG="${SNAPSHOT_SPEC_FILE}.orig"
         if [ ! -f "${SNAPSHOT_SPEC_FILE}" ] ; then
             echo "No valid snapshot file was provided."
             exit 1
         fi
 
-        # The mapped_snapshot file will be overwritten below if the CONFIG_FILE is valid
-        cp "${SNAPSHOT_SPEC_FILE}" "$(workspaces.config.path)/mapped_snapshot.json"
+        # Copy the original Snapshot spec file before overriding
+        cp "${SNAPSHOT_SPEC_FILE}" "${SNAPSHOT_SPEC_FILE_ORIG}"
 
         CONFIG_FILE="$(workspaces.config.path)/$(params.extraConfigPath)"
         if [ ! -f "${CONFIG_FILE}" ] ; then
@@ -64,15 +65,15 @@ spec:
 
         # Merge the mapping key in the config file with the components key in the snapshot based on component name
         # Save the output as a compact json in mapped_snapshot.json file in the workspace
-        { echo -n $(cat "${SNAPSHOT_SPEC_FILE}"); echo "${CONFIG_JSON}"; } | jq -c -s '.[0] as $snapshot
+        { echo -n $(cat "${SNAPSHOT_SPEC_FILE_ORIG}"); echo "${CONFIG_JSON}"; } | jq -c -s '.[0] as $snapshot
           | .[0].components + .[1].mapping.components | group_by(.name) | [.[] | select(length > 1)]
           | map(reduce .[] as $x ({}; . * $x)) as $mergedComponents | $snapshot | .components = $mergedComponents' \
-          > "$(workspaces.config.path)/mapped_snapshot.json"
+          > "${SNAPSHOT_SPEC_FILE}"
 
         echo "true" | tee $(results.mapped.path)
 
         if [ "$(params.failOnEmptyResult)" = "true" ] && \
-          [ $(cat "$(workspaces.config.path)/mapped_snapshot.json" | jq '.components | length') -eq 0 ]
+          [ $(cat "${SNAPSHOT_SPEC_FILE}" | jq '.components | length') -eq 0 ]
         then
           echo "ERROR: Resulting snapshot contains 0 components"
           exit 1

--- a/catalog/task/apply-mapping/0.6/apply-mapping.yaml
+++ b/catalog/task/apply-mapping/0.6/apply-mapping.yaml
@@ -1,0 +1,79 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: apply-mapping
+  labels:
+    app.kubernetes.io/version: "0.5"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Tekton task to apply a mapping to a Snapshot
+  params:
+    - name: snapshotPath
+      type: string
+      description: Path to the JSON string of the Snapshot spec in the config workspace to apply the mapping to
+      default: "snapshot_spec.json"
+    - name: extraConfigPath
+      type: string
+      description: The path to the config file containing the mapping
+      default: ""
+    - name: failOnEmptyResult
+      type: string
+      description: Fail the task if the resulting snapshot contains 0 components
+      default: "false"
+  workspaces:
+    - name: config
+      description: The workspace where the extra config file containing the mapping and snapshot json reside
+  results:
+    - name: mapped
+      description: A true/false value depicting whether or not the snapshot was mapped.
+  steps:
+    - name: apply-mapping
+      image:
+        quay.io/hacbs-release/release-utils@sha256:5733ece907aa70d6ebced36484c936731e8b27bfcf87fed226a0ecf95047a6b8
+      script: |
+        #!/usr/bin/env sh
+        set -eux
+
+        SNAPSHOT_SPEC_FILE="$(workspaces.config.path)/$(params.snapshotPath)"
+        if [ ! -f "${SNAPSHOT_SPEC_FILE}" ] ; then
+            echo "No valid snapshot file was provided."
+            exit 1
+        fi
+
+        # The mapped_snapshot file will be overwritten below if the CONFIG_FILE is valid
+        cp "${SNAPSHOT_SPEC_FILE}" "$(workspaces.config.path)/mapped_snapshot.json"
+
+        CONFIG_FILE="$(workspaces.config.path)/$(params.extraConfigPath)"
+        if [ ! -f "${CONFIG_FILE}" ] ; then
+            echo "No valid config file was provided."
+            echo "false" | tee $(results.mapped.path)
+            exit 0
+        fi
+        if [[ $(yq '.mapping' "${CONFIG_FILE}") == "null" ]] ; then
+            echo "Config file contains no mapping key."
+            echo "false" | tee $(results.mapped.path)
+            exit 0
+        fi
+
+        # Create JSON representation of the config so we can use jq
+        CONFIG_JSON=$(yq -o=json -I=0 '.' "${CONFIG_FILE}")
+
+        # Merge the mapping key in the config file with the components key in the snapshot based on component name
+        # Save the output as a compact json in mapped_snapshot.json file in the workspace
+        { echo -n $(cat "${SNAPSHOT_SPEC_FILE}"); echo "${CONFIG_JSON}"; } | jq -c -s '.[0] as $snapshot
+          | .[0].components + .[1].mapping.components | group_by(.name) | [.[] | select(length > 1)]
+          | map(reduce .[] as $x ({}; . * $x)) as $mergedComponents | $snapshot | .components = $mergedComponents' \
+          > "$(workspaces.config.path)/mapped_snapshot.json"
+
+        echo "true" | tee $(results.mapped.path)
+
+        if [ "$(params.failOnEmptyResult)" = "true" ] && \
+          [ $(cat "$(workspaces.config.path)/mapped_snapshot.json" | jq '.components | length') -eq 0 ]
+        then
+          echo "ERROR: Resulting snapshot contains 0 components"
+          exit 1
+        fi

--- a/catalog/task/apply-mapping/0.6/samples/sample_apply-mapping_TaskRun.yaml
+++ b/catalog/task/apply-mapping/0.6/samples/sample_apply-mapping_TaskRun.yaml
@@ -12,4 +12,4 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: catalog/task/apply-mapping/0.5/apply-mapping.yaml
+        value: catalog/task/apply-mapping/0.6/apply-mapping.yaml

--- a/catalog/task/apply-mapping/0.6/samples/sample_apply-mapping_TaskRun.yaml
+++ b/catalog/task/apply-mapping/0.6/samples/sample_apply-mapping_TaskRun.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: apply-mapping-run-empty-params
+spec:
+  taskRef:
+    resolver: "git"
+    params:
+      - name: url
+        value: https://github.com/redhat-appstudio/release-service-bundles.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: catalog/task/apply-mapping/0.5/apply-mapping.yaml

--- a/catalog/task/apply-mapping/0.6/tests/test-apply-mapping-fail-on-empty.yaml
+++ b/catalog/task/apply-mapping/0.6/tests/test-apply-mapping-fail-on-empty.yaml
@@ -1,0 +1,77 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: test-apply-mapping-fail-on-empty
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the apply-mapping task with a snapshot.spec json and a custom mapping file
+    that results in empty component list. Set task parameter failOnEmptyResult
+    to true and verify that the task fails as expected.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: config
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: config
+        results:
+          - name: snapshot
+        steps:
+          - name: setup-values
+            image: quay.io/hacbs-release/release-utils:5b1a1cd9fd68625cab5573ce62e0d87e6f93f341
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              CONFIG_PATH="$(workspaces.config.path)/config.yaml"
+              cat > $CONFIG_PATH << EOF
+              ---
+              mapping:
+                components:
+                  - name: comp3
+                    repository: repo3
+                  - name: comp4
+                    repository: repo4
+              EOF
+
+              cat > "$(workspaces.config.path)/snapshot_spec.json" << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp1",
+                    "containerImage": "imageurl1",
+                    "source": {
+                      "git": {
+                        "revision": "myrev",
+                        "url": "myurl"
+                      }
+                    }
+                  },
+                  {
+                    "name": "comp2"
+                  }
+                ]
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: apply-mapping
+      params:
+        - name: snapshotPath
+          value: "snapshot_spec.json"
+        - name: extraConfigPath
+          value: "config.yaml"
+        - name: failOnEmptyResult
+          value: "true"
+      workspaces:
+        - name: config
+          workspace: tests-workspace
+      runAfter:
+        - setup

--- a/catalog/task/apply-mapping/0.6/tests/test-apply-mapping-no-mapping.yaml
+++ b/catalog/task/apply-mapping/0.6/tests/test-apply-mapping-no-mapping.yaml
@@ -1,0 +1,82 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: test-apply-mapping-no-mapping
+spec:
+  description: |
+    Run the apply-mapping with a basic snapshot.spec json without any extra config
+    and verify that the returned json is the same as the one on the input.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: config
+          workspace: tests-workspace
+      taskSpec:
+        results:
+          - name: snapshot
+        workspaces:
+          - name: config
+        steps:
+          - name: setup-values
+            image: quay.io/hacbs-release/release-utils:5b1a1cd9fd68625cab5573ce62e0d87e6f93f341
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.config.path)/snapshot_spec.json << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp1",
+                    "containerImage": "imageurl1",
+                    "source": {
+                      "git": {
+                        "revision": "myrev",
+                        "url": "myurl"
+                      }
+                    }
+                  },
+                  {
+                    "name": "comp3",
+                    "repository": "repo3"
+                  },
+                  {
+                    "name": "comp4",
+                    "repository": "repo4"
+                  }
+                ]
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: apply-mapping
+      params:
+        - name: extraConfigPath
+          value: ""
+      workspaces:
+        - name: config
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      workspaces:
+        - name: config
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: config
+        steps:
+          - name: check-result
+            image: quay.io/hacbs-release/release-utils:5b1a1cd9fd68625cab5573ce62e0d87e6f93f341
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              # the resulting json is exactly the same as the original one (since no mapping file was used)
+              test "$(echo $ORIG|jq --sort-keys .)" == "$(echo $MAPPED|jq --sort-keys .)"
+      runAfter:
+        - run-task

--- a/catalog/task/apply-mapping/0.6/tests/test-apply-mapping-no-mapping.yaml
+++ b/catalog/task/apply-mapping/0.6/tests/test-apply-mapping-no-mapping.yaml
@@ -77,6 +77,7 @@ spec:
               set -eux
 
               # the resulting json is exactly the same as the original one (since no mapping file was used)
-              test "$(echo $ORIG|jq --sort-keys .)" == "$(echo $MAPPED|jq --sort-keys .)"
+              test "$(cat $(workspaces.config.path)/snapshot_spec.json|jq --sort-keys .)" \
+                == "$(cat $(workspaces.config.path)/snapshot_spec.json.orig|jq --sort-keys .)"
       runAfter:
         - run-task

--- a/catalog/task/apply-mapping/0.6/tests/test-apply-mapping.yaml
+++ b/catalog/task/apply-mapping/0.6/tests/test-apply-mapping.yaml
@@ -96,27 +96,27 @@ spec:
               set -eux
 
               echo Test that SNAPSHOT contains component comp1
-              test $(cat $(workspaces.config.path)/mapped_snapshot.json \
+              test $(cat $(workspaces.config.path)/test_snapshot_spec.json \
                 | jq -r '[ .components[] | select(.name=="comp1") ] | length') -eq 1
 
               echo Test that SNAPSHOT contains repository from the mapping file
-              test $(cat $(workspaces.config.path)/mapped_snapshot.json \
+              test $(cat $(workspaces.config.path)/test_snapshot_spec.json \
                 | jq -r '.components[] | select(.name=="comp1") | .repository') == repo1
 
               echo Test that SNAPSHOT does not contain component comp2
-              test $(cat $(workspaces.config.path)/mapped_snapshot.json \
+              test $(cat $(workspaces.config.path)/test_snapshot_spec.json \
                 | jq -r '[ .components[] | select(.name=="comp2") ] | length') -eq 0
 
               echo Test that repository of component comp3 was overriden by mapping file
-              test $(cat $(workspaces.config.path)/mapped_snapshot.json \
+              test $(cat $(workspaces.config.path)/test_snapshot_spec.json \
                 | jq -r '.components[] | select(.name=="comp3") | .repository') == repo3a
 
               echo Test that repository of component comp4 stayed intact
-              test $(cat $(workspaces.config.path)/mapped_snapshot.json \
+              test $(cat $(workspaces.config.path)/test_snapshot_spec.json \
                 | jq -r '.components[] | select(.name=="comp4") | .repository') == repo4
 
               echo Test that SNAPSHOT does not contain component comp5 as it was not included in the mapping file
-              test $(cat $(workspaces.config.path)/mapped_snapshot.json \
+              test $(cat $(workspaces.config.path)/test_snapshot_spec.json \
                 | jq -r '[ .components[] | select(.name=="comp5") ] | length') -eq 0
       runAfter:
         - run-task

--- a/catalog/task/apply-mapping/0.6/tests/test-apply-mapping.yaml
+++ b/catalog/task/apply-mapping/0.6/tests/test-apply-mapping.yaml
@@ -1,0 +1,122 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: test-apply-mapping
+spec:
+  description: |
+    Run the apply-mapping task with a snapshot.spec json and a custom mapping file
+    and verify that the resulting json contains the expected values.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: config
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: config
+        steps:
+          - name: setup-values
+            image: quay.io/hacbs-release/release-utils:5b1a1cd9fd68625cab5573ce62e0d87e6f93f341
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              CONFIG_PATH="$(workspaces.config.path)/config.yaml"
+              cat > $CONFIG_PATH << EOF
+              ---
+              mapping:
+                components:
+                  - name: comp1
+                    repository: repo1
+                  - name: comp2
+                    repository: repo2
+                  - name: comp3
+                    repository: repo3a
+                  - name: comp4
+                    customfield: custom
+              EOF
+
+              cat > $(workspaces.config.path)/test_snapshot_spec.json << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp1",
+                    "containerImage": "imageurl1",
+                    "source": {
+                      "git": {
+                        "revision": "myrev",
+                        "url": "myurl"
+                      }
+                    }
+                  },
+                  {
+                    "name": "comp3",
+                    "repository": "repo3"
+                  },
+                  {
+                    "name": "comp4",
+                    "repository": "repo4"
+                  },
+                  {
+                    "name": "comp5",
+                    "containerImage": "imageurl5"
+                  }
+                ]
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: apply-mapping
+      params:
+        - name: snapshotPath
+          value: test_snapshot_spec.json
+        - name: extraConfigPath
+          value: "config.yaml"
+      runAfter:
+        - setup
+      workspaces:
+        - name: config
+          workspace: tests-workspace
+    - name: check-result
+      workspaces:
+        - name: config
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: config
+        steps:
+          - name: check-result
+            image: quay.io/hacbs-release/release-utils:5b1a1cd9fd68625cab5573ce62e0d87e6f93f341
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              echo Test that SNAPSHOT contains component comp1
+              test $(cat $(workspaces.config.path)/mapped_snapshot.json \
+                | jq -r '[ .components[] | select(.name=="comp1") ] | length') -eq 1
+
+              echo Test that SNAPSHOT contains repository from the mapping file
+              test $(cat $(workspaces.config.path)/mapped_snapshot.json \
+                | jq -r '.components[] | select(.name=="comp1") | .repository') == repo1
+
+              echo Test that SNAPSHOT does not contain component comp2
+              test $(cat $(workspaces.config.path)/mapped_snapshot.json \
+                | jq -r '[ .components[] | select(.name=="comp2") ] | length') -eq 0
+
+              echo Test that repository of component comp3 was overriden by mapping file
+              test $(cat $(workspaces.config.path)/mapped_snapshot.json \
+                | jq -r '.components[] | select(.name=="comp3") | .repository') == repo3a
+
+              echo Test that repository of component comp4 stayed intact
+              test $(cat $(workspaces.config.path)/mapped_snapshot.json \
+                | jq -r '.components[] | select(.name=="comp4") | .repository') == repo4
+
+              echo Test that SNAPSHOT does not contain component comp5 as it was not included in the mapping file
+              test $(cat $(workspaces.config.path)/mapped_snapshot.json \
+                | jq -r '[ .components[] | select(.name=="comp5") ] | length') -eq 0
+      runAfter:
+        - run-task

--- a/catalog/task/collect-data/0.2/README.md
+++ b/catalog/task/collect-data/0.2/README.md
@@ -1,0 +1,18 @@
+# collect-data
+
+Tekton task to collect the information added to the extraData field of the release resources.
+
+The purpose of this task is to collect all the extra data and supply it to the other task in the pipeline by creating
+a json file called `extra-data.json` in the workspace.
+
+This task also stores the passed resources as json files in a workspace.
+
+## Parameters
+
+| Name                 | Description                                        | Optional | Default value |
+|----------------------|----------------------------------------------------|----------|---------------|
+| release              | Namespaced name of the Release                     | No       | -             |
+| releaseplan          | Namespaced name of the ReleasePlan                 | No       | -             |
+| releaseplanadmission | Namespaced name of the ReleasePlanAdmission        | No       | -             |
+| releasestrategy      | Namespaced name of the ReleaseStrategy             | No       | -             |
+| snapshot             | Namespaced name of the Snapshot                    | No       | -             |

--- a/catalog/task/collect-data/0.2/README.md
+++ b/catalog/task/collect-data/0.2/README.md
@@ -16,7 +16,7 @@ This task also stores the passed resources as json files in a workspace.
 | releaseplanadmission | Namespaced name of the ReleasePlanAdmission        | No       | -             |
 | releasestrategy      | Namespaced name of the ReleaseStrategy             | No       | -             |
 | snapshot             | Namespaced name of the Snapshot                    | No       | -             |
-| subdirectory      | Subdirectory inside the workspace to be used. | Yes       | -             |
+| subdirectory         | Subdirectory inside the workspace to be used.      | Yes      | -             |
 
 ## Changes since 0.1
   * Added new `subdirectory` parameter to specify a subdirectory inside the workspace dir to be used

--- a/catalog/task/collect-data/0.2/README.md
+++ b/catalog/task/collect-data/0.2/README.md
@@ -16,3 +16,7 @@ This task also stores the passed resources as json files in a workspace.
 | releaseplanadmission | Namespaced name of the ReleasePlanAdmission        | No       | -             |
 | releasestrategy      | Namespaced name of the ReleaseStrategy             | No       | -             |
 | snapshot             | Namespaced name of the Snapshot                    | No       | -             |
+| subdirectory      | Subdirectory inside the workspace to be used. | Yes       | -             |
+
+## Changes since 0.1
+  * Added new `subdirectory` parameter to specify a subdirectory inside the workspace dir to be used

--- a/catalog/task/collect-data/0.2/collect-data.yaml
+++ b/catalog/task/collect-data/0.2/collect-data.yaml
@@ -27,6 +27,10 @@ spec:
     - name: snapshot
       type: string
       description: The namespaced name of the Snapshot
+    - name: subdirectory
+      description: Subdirectory inside the workspace to be used
+      type: string
+      default: ""
   workspaces:
     - name: data
       description: Workspace to save the CR jsons to
@@ -47,22 +51,28 @@ spec:
           value: '$(params.releasestrategy)'
         - name: "SNAPSHOT"
           value: '$(params.snapshot)'
+        - name: "SUBDIR"
+          value: '$(workspaces.data.path)/$(params.subdirectory)'
       script: |
         #!/usr/bin/env sh
         set -e
 
-        get-resource "release" "${RELEASE}" > "$(workspaces.data.path)/release.json"
+        if [ -n "$(params.subdirectory)" ]; then
+          mkdir -p $SUBDIR
+        fi
 
-        get-resource "releaseplan" "${RELEASE_PLAN}" > "$(workspaces.data.path)/release_plan.json"
+        get-resource "release" "${RELEASE}" > "$SUBDIR/release.json"
+
+        get-resource "releaseplan" "${RELEASE_PLAN}" > "$SUBDIR/release_plan.json"
 
         get-resource "releaseplanadmission" "${RELEASE_PLAN_ADMISSION}" \
-          > "$(workspaces.data.path)/release_plan_admission.json"
+          > "$SUBDIR/release_plan_admission.json"
 
-        get-resource "releasestrategy" "${RELEASE_STRATEGY}" > "$(workspaces.data.path)/release_strategy.json"
+        get-resource "releasestrategy" "${RELEASE_STRATEGY}" > "$SUBDIR/release_strategy.json"
 
-        get-resource "snapshot" "${SNAPSHOT}" "{.spec}" > "$(workspaces.data.path)/snapshot_spec.json"
+        get-resource "snapshot" "${SNAPSHOT}" "{.spec}" > "$SUBDIR/snapshot_spec.json"
 
-        cat "$(workspaces.data.path)/snapshot_spec.json" | jq '.components[0].containerImage' \
+        cat "$SUBDIR/snapshot_spec.json" | jq -cr '.components[0].containerImage' | tr -d "\n" \
           | tee $(results.fbcFragment.path)
 
         release_result=$(get-resource "release" "${RELEASE}" "{.spec.extraData}")
@@ -78,4 +88,4 @@ spec:
         # Merge now with ReleasePlanAdmission keys. ReleasePlanAdmission has higher priority
         merged_output=$(merge-json "$release_result" "$release_plan_admission_result")
 
-        echo "$merged_output" > "$(workspaces.data.path)/extra_data.json"
+        echo "$merged_output" > "$SUBDIR/extra_data.json"

--- a/catalog/task/collect-data/0.2/collect-data.yaml
+++ b/catalog/task/collect-data/0.2/collect-data.yaml
@@ -1,0 +1,81 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: collect-data
+  labels:
+    app.kubernetes.io/version: "0.2"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Tekton task to collect extra data from release resources and optionally save CRs to a workspace
+  params:
+    - name: release
+      type: string
+      description: The namespaced name of the Release
+    - name: releaseplan
+      type: string
+      description: The namespaced name of the ReleasePlan
+    - name: releaseplanadmission
+      type: string
+      description: The namespaced name of the ReleasePlanAdmission
+    - name: releasestrategy
+      type: string
+      description: The namespaced name of the ReleaseStrategy
+    - name: snapshot
+      type: string
+      description: The namespaced name of the Snapshot
+  workspaces:
+    - name: data
+      description: Workspace to save the CR jsons to
+  results:
+    - name: fbcFragment
+      description: The first component's containerImage in the snapshot to use in the fbc pipelines
+  steps:
+    - name: collect-data
+      image: quay.io/hacbs-release/release-utils:4d8649dbb2b626f5fe9f4ff83c1bc3be268fad31
+      env:
+        - name: "RELEASE"
+          value: '$(params.release)'
+        - name: "RELEASE_PLAN"
+          value: '$(params.releaseplan)'
+        - name: "RELEASE_PLAN_ADMISSION"
+          value: '$(params.releaseplanadmission)'
+        - name: "RELEASE_STRATEGY"
+          value: '$(params.releasestrategy)'
+        - name: "SNAPSHOT"
+          value: '$(params.snapshot)'
+      script: |
+        #!/usr/bin/env sh
+        set -e
+
+        get-resource "release" "${RELEASE}" > "$(workspaces.data.path)/release.json"
+
+        get-resource "releaseplan" "${RELEASE_PLAN}" > "$(workspaces.data.path)/release_plan.json"
+
+        get-resource "releaseplanadmission" "${RELEASE_PLAN_ADMISSION}" \
+          > "$(workspaces.data.path)/release_plan_admission.json"
+
+        get-resource "releasestrategy" "${RELEASE_STRATEGY}" > "$(workspaces.data.path)/release_strategy.json"
+
+        get-resource "snapshot" "${SNAPSHOT}" "{.spec}" > "$(workspaces.data.path)/snapshot_spec.json"
+
+        cat "$(workspaces.data.path)/snapshot_spec.json" | jq '.components[0].containerImage' \
+          | tee $(results.fbcFragment.path)
+
+        release_result=$(get-resource "release" "${RELEASE}" "{.spec.extraData}")
+
+        release_plan_result=$(get-resource "releaseplan" "${RELEASE_PLAN}" "{.spec.extraData}")
+
+        release_plan_admission_result=$(get-resource "releaseplanadmission" "${RELEASE_PLAN_ADMISSION}" \
+            "{.spec.extraData}")
+
+        # Merge Release and ReleasePlan keys. ReleasePlan has higher priority
+        merged_output=$(merge-json "$release_result" "$release_plan_result")
+
+        # Merge now with ReleasePlanAdmission keys. ReleasePlanAdmission has higher priority
+        merged_output=$(merge-json "$release_result" "$release_plan_admission_result")
+
+        echo "$merged_output" > "$(workspaces.data.path)/extra_data.json"

--- a/catalog/task/collect-data/0.2/collect-data.yaml
+++ b/catalog/task/collect-data/0.2/collect-data.yaml
@@ -61,18 +61,20 @@ spec:
           mkdir -p $SUBDIR
         fi
 
-        get-resource "release" "${RELEASE}" > "$SUBDIR/release.json"
+        cd $SUBDIR
 
-        get-resource "releaseplan" "${RELEASE_PLAN}" > "$SUBDIR/release_plan.json"
+        get-resource "release" "${RELEASE}" > "release.json"
+
+        get-resource "releaseplan" "${RELEASE_PLAN}" > "release_plan.json"
 
         get-resource "releaseplanadmission" "${RELEASE_PLAN_ADMISSION}" \
-          > "$SUBDIR/release_plan_admission.json"
+          > "release_plan_admission.json"
 
-        get-resource "releasestrategy" "${RELEASE_STRATEGY}" > "$SUBDIR/release_strategy.json"
+        get-resource "releasestrategy" "${RELEASE_STRATEGY}" > "release_strategy.json"
 
-        get-resource "snapshot" "${SNAPSHOT}" "{.spec}" > "$SUBDIR/snapshot_spec.json"
+        get-resource "snapshot" "${SNAPSHOT}" "{.spec}" > "snapshot_spec.json"
 
-        cat "$SUBDIR/snapshot_spec.json" | jq -cr '.components[0].containerImage' | tr -d "\n" \
+        cat "snapshot_spec.json" | jq -cr '.components[0].containerImage' | tr -d "\n" \
           | tee $(results.fbcFragment.path)
 
         release_result=$(get-resource "release" "${RELEASE}" "{.spec.extraData}")
@@ -88,4 +90,4 @@ spec:
         # Merge now with ReleasePlanAdmission keys. ReleasePlanAdmission has higher priority
         merged_output=$(merge-json "$release_result" "$release_plan_admission_result")
 
-        echo "$merged_output" > "$SUBDIR/extra_data.json"
+        echo "$merged_output" > "extra_data.json"

--- a/catalog/task/collect-data/0.2/samples/sample_collect-extra-data_TaskRun.yaml
+++ b/catalog/task/collect-data/0.2/samples/sample_collect-extra-data_TaskRun.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: collect-data-run
+spec:
+  params:
+    - name: release
+      value: "default/release"
+    - name: releaseplan
+      value: "default/release-plan"
+    - name: releaseplanadmission
+      value: "default/release-plan-admission"
+    - name: releasestrategy
+      value: "default/release-strategy"
+    - name: snapshot
+      value: "default/snapshot"
+  taskRef:
+    resolver: "git"
+    params:
+      - name: url
+        value: https://github.com/redhat-appstudio/release-service-bundles.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: catalog/task/collect-data/0.1/collect-data.yaml

--- a/catalog/task/collect-data/0.2/samples/sample_collect-extra-data_TaskRun.yaml
+++ b/catalog/task/collect-data/0.2/samples/sample_collect-extra-data_TaskRun.yaml
@@ -23,4 +23,4 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: catalog/task/collect-data/0.1/collect-data.yaml
+        value: catalog/task/collect-data/0.2/collect-data.yaml

--- a/catalog/task/collect-data/0.2/tests/pre-apply-task-hook.sh
+++ b/catalog/task/collect-data/0.2/tests/pre-apply-task-hook.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# Install the CRDs so we can create/get them
+.github/scripts/install_crds.sh
+
+# Add RBAC so that the SA executing the tests can retrieve CRs
+kubectl apply -f .github/resources/crd_rbac.yaml

--- a/catalog/task/collect-data/0.2/tests/test-collect-data-fail-missing-cr.yaml
+++ b/catalog/task/collect-data/0.2/tests/test-collect-data-fail-missing-cr.yaml
@@ -1,0 +1,103 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: test-collect-data-fail-missing-cr
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the collect-data task without a snapshot cr and verify that the task fails as expected.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: create-crs
+            image: quay.io/hacbs-release/release-utils:4d8649dbb2b626f5fe9f4ff83c1bc3be268fad31
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > release << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: Release
+              metadata:
+                name: release-sample
+                namespace: default
+              spec:
+                snapshot: foo
+                releasePlan: foo
+              EOF
+              kubectl apply -f release
+
+              cat > releaseplan << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: ReleasePlan
+              metadata:
+                name: releaseplan-sample
+                namespace: default
+              spec:
+                application: foo
+                target: foo
+              EOF
+              kubectl apply -f releaseplan
+
+              cat > releaseplanadmission << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: ReleasePlanAdmission
+              metadata:
+                name: releaseplanadmission-sample
+                namespace: default
+              spec:
+                application: foo
+                origin: foo
+                releaseStrategy: foo
+              EOF
+              kubectl apply -f releaseplanadmission
+
+              cat > releasestrategy << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: ReleaseStrategy
+              metadata:
+                name: releasestrategy-sample
+                namespace: default
+              spec:
+                pipeline: foo
+                policy: foo
+              EOF
+              kubectl apply -f releasestrategy
+    - name: run-task
+      taskRef:
+        name: collect-data
+      params:
+        - name: release
+          value: default/release-sample
+        - name: releaseplan
+          value: default/releaseplan-sample
+        - name: releaseplanadmission
+          value: default/releaseplanadmission-sample
+        - name: releasestrategy
+          value: default/releasestrategy-sample
+        - name: snapshot
+          value: default/snapshot-sample
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: check-result
+            image: quay.io/hacbs-release/release-utils:4d8649dbb2b626f5fe9f4ff83c1bc3be268fad31
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              kubectl delete release release-sample
+              kubectl delete releaseplan releaseplan-sample
+              kubectl delete releaseplanadmission releaseplanadmission-sample
+              kubectl delete releasestrategy releasestrategy-sample

--- a/catalog/task/collect-data/0.2/tests/test-collect-data-fail-missing-cr.yaml
+++ b/catalog/task/collect-data/0.2/tests/test-collect-data-fail-missing-cr.yaml
@@ -82,6 +82,8 @@ spec:
           value: default/releasestrategy-sample
         - name: snapshot
           value: default/snapshot-sample
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
       runAfter:
         - setup
       workspaces:
@@ -91,7 +93,7 @@ spec:
     - name: cleanup
       taskSpec:
         steps:
-          - name: check-result
+          - name: delete-crs
             image: quay.io/hacbs-release/release-utils:4d8649dbb2b626f5fe9f4ff83c1bc3be268fad31
             script: |
               #!/usr/bin/env sh

--- a/catalog/task/collect-data/0.2/tests/test-collect-data-with-extra-data.yaml
+++ b/catalog/task/collect-data/0.2/tests/test-collect-data-with-extra-data.yaml
@@ -100,6 +100,8 @@ spec:
           value: default/releasestrategy-sample
         - name: snapshot
           value: default/snapshot-sample
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
       runAfter:
         - setup
       workspaces:
@@ -119,14 +121,14 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
-              EXTRA_DATA_JSON=$(cat "$(workspaces.data.path)/extra_data.json")
+              EXTRA_DATA_JSON=$(cat "$(workspaces.data.path)/$(context.pipelineRun.uid)/extra_data.json")
               echo Test that extraData result was set properly
               test $EXTRA_DATA_JSON == '{"foo":"bar","one":{"four":["five","six"],"two":"three"}}'
   finally:
     - name: cleanup
       taskSpec:
         steps:
-          - name: check-result
+          - name: delete-crs
             image: quay.io/hacbs-release/release-utils:4d8649dbb2b626f5fe9f4ff83c1bc3be268fad31
             script: |
               #!/usr/bin/env sh

--- a/catalog/task/collect-data/0.2/tests/test-collect-data-with-extra-data.yaml
+++ b/catalog/task/collect-data/0.2/tests/test-collect-data-with-extra-data.yaml
@@ -1,0 +1,139 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: test-collect-data-with-extra-data
+spec:
+  description: |
+    Run the collect-data task and verify that extraData task result is accurate.
+    Releases and ReleasePlans don't currently support extraData, so it is only
+    added to the ReleasePlanAdmission.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: create-crs
+            image: quay.io/hacbs-release/release-utils:4d8649dbb2b626f5fe9f4ff83c1bc3be268fad31
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > release << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: Release
+              metadata:
+                name: release-sample
+                namespace: default
+              spec:
+                snapshot: foo
+                releasePlan: foo
+              EOF
+              kubectl apply -f release
+
+              cat > releaseplan << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: ReleasePlan
+              metadata:
+                name: releaseplan-sample
+                namespace: default
+              spec:
+                application: foo
+                target: foo
+              EOF
+              kubectl apply -f releaseplan
+
+              cat > releaseplanadmission << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: ReleasePlanAdmission
+              metadata:
+                name: releaseplanadmission-sample
+                namespace: default
+              spec:
+                application: foo
+                origin: foo
+                releaseStrategy: foo
+                extraData:
+                  foo: bar
+                  one:
+                    two: three
+                    four:
+                      - five
+                      - six
+              EOF
+              kubectl apply -f releaseplanadmission
+
+              cat > releasestrategy << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: ReleaseStrategy
+              metadata:
+                name: releasestrategy-sample
+                namespace: default
+              spec:
+                pipeline: foo
+                policy: foo
+              EOF
+              kubectl apply -f releasestrategy
+
+              cat > snapshot << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: Snapshot
+              metadata:
+                name: snapshot-sample
+                namespace: default
+              spec:
+                application: foo
+              EOF
+              kubectl apply -f snapshot
+    - name: run-task
+      taskRef:
+        name: collect-data
+      params:
+        - name: release
+          value: default/release-sample
+        - name: releaseplan
+          value: default/releaseplan-sample
+        - name: releaseplanadmission
+          value: default/releaseplanadmission-sample
+        - name: releasestrategy
+          value: default/releasestrategy-sample
+        - name: snapshot
+          value: default/snapshot-sample
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: check-result
+      runAfter:
+        - run-task
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        steps:
+          - name: check-result
+            image: quay.io/hacbs-release/release-utils:4d8649dbb2b626f5fe9f4ff83c1bc3be268fad31
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              EXTRA_DATA_JSON=$(cat "$(workspaces.data.path)/extra_data.json")
+              echo Test that extraData result was set properly
+              test $EXTRA_DATA_JSON == '{"foo":"bar","one":{"four":["five","six"],"two":"three"}}'
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: check-result
+            image: quay.io/hacbs-release/release-utils:4d8649dbb2b626f5fe9f4ff83c1bc3be268fad31
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              kubectl delete release release-sample
+              kubectl delete releaseplan releaseplan-sample
+              kubectl delete releaseplanadmission releaseplanadmission-sample
+              kubectl delete releasestrategy releasestrategy-sample
+              kubectl delete snapshot snapshot-sample

--- a/catalog/task/collect-data/0.2/tests/test-collect-data.yaml
+++ b/catalog/task/collect-data/0.2/tests/test-collect-data.yaml
@@ -1,0 +1,160 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: test-collect-data
+spec:
+  description: |
+    Run the collect-data task and verify that all resources are stored in the workspace.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: create-crs
+            image: quay.io/hacbs-release/release-utils:4d8649dbb2b626f5fe9f4ff83c1bc3be268fad31
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > release << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: Release
+              metadata:
+                name: release-sample
+                namespace: default
+              spec:
+                snapshot: foo
+                releasePlan: foo
+              EOF
+              kubectl apply -f release
+
+              cat > releaseplan << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: ReleasePlan
+              metadata:
+                name: releaseplan-sample
+                namespace: default
+              spec:
+                application: foo
+                target: foo
+              EOF
+              kubectl apply -f releaseplan
+
+              cat > releaseplanadmission << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: ReleasePlanAdmission
+              metadata:
+                name: releaseplanadmission-sample
+                namespace: default
+              spec:
+                application: foo
+                origin: foo
+                releaseStrategy: foo
+              EOF
+              kubectl apply -f releaseplanadmission
+
+              cat > releasestrategy << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: ReleaseStrategy
+              metadata:
+                name: releasestrategy-sample
+                namespace: default
+              spec:
+                pipeline: foo
+                policy: foo
+              EOF
+              kubectl apply -f releasestrategy
+
+              cat > snapshot << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: Snapshot
+              metadata:
+                name: snapshot-sample
+                namespace: default
+              spec:
+                application: foo
+                components:
+                  - name: name
+                    containerImage: newimage
+              EOF
+              kubectl apply -f snapshot
+    - name: run-task
+      taskRef:
+        name: collect-data
+      params:
+        - name: release
+          value: default/release-sample
+        - name: releaseplan
+          value: default/releaseplan-sample
+        - name: releaseplanadmission
+          value: default/releaseplanadmission-sample
+        - name: releasestrategy
+          value: default/releasestrategy-sample
+        - name: snapshot
+          value: default/snapshot-sample
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: check-result
+      params:
+        - name: fbcFragment
+          value: $(tasks.run-task.results.fbcFragment)
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - run-task
+      taskSpec:
+        params:
+          - name: fbcFragment
+            type: string
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/hacbs-release/release-utils:4d8649dbb2b626f5fe9f4ff83c1bc3be268fad31
+            env:
+              - name: "FBC_FRAGMENT"
+                value: '$(params.fbcFragment)'
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              echo Test that Release CR was saved to workspace
+              test $(cat "$(workspaces.data.path)/release.json" | jq -r '.metadata.name') == release-sample
+
+              echo Test that ReleasePlan CR was saved to workspace
+              test $(cat "$(workspaces.data.path)/release_plan.json" | jq -r '.metadata.name') == releaseplan-sample
+
+              echo Test that ReleasePlanAdmission CR was saved to workspace
+              test $(cat "$(workspaces.data.path)/release_plan_admission.json" \
+                  | jq -r '.metadata.name') == releaseplanadmission-sample
+
+              echo Test that ReleaseStrategy CR was saved to workspace
+              test $(cat "$(workspaces.data.path)/release_strategy.json" \
+                  | jq -r '.metadata.name') == releasestrategy-sample
+
+              echo Test that Snapshot spec was saved to workspace
+              test $(cat "$(workspaces.data.path)/snapshot_spec.json" | jq -r '.application') == foo
+
+              echo Test the fbcFragment result was properly set
+              test $(echo $FBC_FRAGMENT) == '"newimage"'
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: check-result
+            image: quay.io/hacbs-release/release-utils:4d8649dbb2b626f5fe9f4ff83c1bc3be268fad31
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              kubectl delete release release-sample
+              kubectl delete releaseplan releaseplan-sample
+              kubectl delete releaseplanadmission releaseplanadmission-sample
+              kubectl delete releasestrategy releasestrategy-sample
+              kubectl delete snapshot snapshot-sample

--- a/catalog/task/collect-data/0.2/tests/test-collect-data.yaml
+++ b/catalog/task/collect-data/0.2/tests/test-collect-data.yaml
@@ -94,6 +94,8 @@ spec:
           value: default/releasestrategy-sample
         - name: snapshot
           value: default/snapshot-sample
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
       runAfter:
         - setup
       workspaces:
@@ -120,34 +122,36 @@ spec:
             env:
               - name: "FBC_FRAGMENT"
                 value: '$(params.fbcFragment)'
+              - name: SUBDIR
+                value: $(workspaces.data.path)/$(context.pipelineRun.uid)
             script: |
               #!/usr/bin/env sh
               set -eux
 
               echo Test that Release CR was saved to workspace
-              test $(cat "$(workspaces.data.path)/release.json" | jq -r '.metadata.name') == release-sample
+              test $(cat "$SUBDIR/release.json" | jq -r '.metadata.name') == release-sample
 
               echo Test that ReleasePlan CR was saved to workspace
-              test $(cat "$(workspaces.data.path)/release_plan.json" | jq -r '.metadata.name') == releaseplan-sample
+              test $(cat "$SUBDIR/release_plan.json" | jq -r '.metadata.name') == releaseplan-sample
 
               echo Test that ReleasePlanAdmission CR was saved to workspace
-              test $(cat "$(workspaces.data.path)/release_plan_admission.json" \
+              test $(cat "$SUBDIR/release_plan_admission.json" \
                   | jq -r '.metadata.name') == releaseplanadmission-sample
 
               echo Test that ReleaseStrategy CR was saved to workspace
-              test $(cat "$(workspaces.data.path)/release_strategy.json" \
+              test $(cat "$SUBDIR/release_strategy.json" \
                   | jq -r '.metadata.name') == releasestrategy-sample
 
               echo Test that Snapshot spec was saved to workspace
-              test $(cat "$(workspaces.data.path)/snapshot_spec.json" | jq -r '.application') == foo
+              test $(cat "$SUBDIR/snapshot_spec.json" | jq -r '.application') == foo
 
               echo Test the fbcFragment result was properly set
-              test $(echo $FBC_FRAGMENT) == '"newimage"'
+              test $(echo $FBC_FRAGMENT) == "newimage"
   finally:
     - name: cleanup
       taskSpec:
         steps:
-          - name: check-result
+          - name: delete-crs
             image: quay.io/hacbs-release/release-utils:4d8649dbb2b626f5fe9f4ff83c1bc3be268fad31
             script: |
               #!/usr/bin/env sh


### PR DESCRIPTION
This is to avoid multiple PRs running in parallel overriding each other's data.

This updates the tasks to be able to use a subdirectory inside a workspace.

There will be another PR to update the pipelines to use these.