### PR TITLE
feat(HACBS-2471): Add slack support to rhtap service push

### DIFF
--- a/catalog/pipeline/rhtap-service-push/0.1/rhtap-service-push.yaml
+++ b/catalog/pipeline/rhtap-service-push/0.1/rhtap-service-push.yaml
@@ -257,6 +257,22 @@ spec:
       runAfter:
         - push-sbom-to-pyxis
   finally:
+    - name: slack-webhook-notification
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/slack-webhook-notification/0.1/slack-webhook-notification.yaml
+      params:
+        - name: message
+          value: Release pipelineRun $(context.pipelineRun.name) $(tasks.status)
+      workspaces:
+        - name: data
+          workspace: release-workspace
     - name: cleanup
       taskRef:
         resolver: "git"


### PR DESCRIPTION
- add slack-webhook-notification to rhtap-service-push pipeline in finally section.