### PR TITLE
feat(HACBS-2506): add revert prefix support

### DIFF
--- a/.github/gitlint/contrib_format_conventional_commits.py
+++ b/.github/gitlint/contrib_format_conventional_commits.py
@@ -15,7 +15,7 @@ class ConventionalCommitsFormat(CommitRule):
         """Validate the given commit checking that the title has a
         proper prefix and the description starts with a lowercase."""
 
-        regex_string = "^(chore|docs|feat|fix|refactor|style|test)(\(.*\))?: [a-z].*$"
+        regex_string = "^(chore|docs|feat|fix|refactor|revert|style|test)(\(.*\))?: [a-z].*$"
         pattern = re.compile(regex_string)
         if not pattern.match(commit.message.title):
             return [


### PR DESCRIPTION
Updates gitlint to support "revert" as a prefix