### PR TITLE
fix(HACBS-2533): fbc-release pipelinerun failing

### DIFF
--- a/catalog/task/collect-data/0.1/collect-data.yaml
+++ b/catalog/task/collect-data/0.1/collect-data.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: collect-data
   labels:
-    app.kubernetes.io/version: "0.2"
+    app.kubernetes.io/version: "0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -62,7 +62,7 @@ spec:
 
         get-resource "snapshot" "${SNAPSHOT}" "{.spec}" > "$(workspaces.data.path)/snapshot_spec.json"
 
-        cat "$(workspaces.data.path)/snapshot_spec.json" | jq '.components[0].containerImage' \
+        cat "$(workspaces.data.path)/snapshot_spec.json" | jq -cr '.components[0].containerImage' | tr -d "\n" \
           | tee $(results.fbcFragment.path)
 
         release_result=$(get-resource "release" "${RELEASE}" "{.spec.extraData}")

--- a/catalog/task/collect-data/0.1/tests/test-collect-data.yaml
+++ b/catalog/task/collect-data/0.1/tests/test-collect-data.yaml
@@ -142,7 +142,7 @@ spec:
               test $(cat "$(workspaces.data.path)/snapshot_spec.json" | jq -r '.application') == foo
 
               echo Test the fbcFragment result was properly set
-              test $(echo $FBC_FRAGMENT) == '"newimage"'
+              test $(echo $FBC_FRAGMENT) == "newimage"
   finally:
     - name: cleanup
       taskSpec:


### PR DESCRIPTION
The fbc-release's task `add-fbc-add-fbc-contribution-to-index-image`
is failing due to an extra "\n" added by `collectd-data` to the
fbcFragment result, which is now used by the task.
