### PR TITLE
fix: improve reliability of test_tekton_task script

### DIFF
--- a/.github/scripts/test_tekton_tasks.sh
+++ b/.github/scripts/test_tekton_tasks.sh
@@ -103,12 +103,13 @@ do
 
     PIPELINERUN=$(tkn p start $TEST_NAME -w name=tests-workspace,volumeClaimTemplateFile=$WORKSPACE_TEMPLATE -o json | jq -r '.metadata.name')
     echo "  Started pipelinerun $PIPELINERUN"
-    tkn pr logs $PIPELINERUN -f
+    sleep 1  # allow a second for the pr object to appear (including a status condition)
     while [ "$(kubectl get pr $PIPELINERUN -o=jsonpath='{.status.conditions[0].status}')" == "Unknown" ]
     do
-      echo "  PipelineRun $PIPELINERUN status Unknown. Waiting for update..."
+      echo "  PipelineRun $PIPELINERUN in progress (status Unknown). Waiting for update..."
       sleep 5
     done
+    tkn pr logs $PIPELINERUN
 
     PR_STATUS=$(kubectl get pr $PIPELINERUN -o=jsonpath='{.status.conditions[0].status}')
 


### PR DESCRIPTION
This script runs as part of PR checks on Github
and sometimes it gets stuck on this command:
`tkn pr logs $PIPELINERUN -f`

"-f" stands for follow. It seems sometimes it has issues following the logs - it does and then gets stuck.

This should avoid the issue, but at the price
of not being able to see the log live as
the PR runs. It will be spit out once the PR finishes.

This came up during review of https://github.com/redhat-appstudio/release-service-bundles/pull/169