### PR TITLE
fix(RHTAPBUGS-560): update pipelines to use subdirectory

### DIFF
--- a/catalog/pipeline/deploy-release/0.6/README.md
+++ b/catalog/pipeline/deploy-release/0.6/README.md
@@ -1,0 +1,34 @@
+# Release Pipeline
+
+Tekton pipeline to verify Snapshot prior to Deployment
+
+## Parameters
+
+| Name | Description | Optional | Default value |
+|------|-------------|----------|---------------|
+| release | The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution | No | - |
+| releaseplan | The namespaced name (namespace/name) of the releasePlan | No | - |
+| releaseplanadmission | The namespaced name (namespace/name) of the releasePlanAdmission | No | - |
+| releasestrategy | The namespaced name (namespace/name) of the releaseStrategy | No | - |
+| snapshot | The namespaced name (namespace/name) of the snapshot | No | - |
+| enterpriseContractPolicy | JSON representation of the policy to be applied when validating the enterprise contract | No | - |
+| verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
+
+## Changes since 0.4
+- git resolvers are used in place of release bundle resolvers
+
+## Changes since 0.3
+- the collect-data task was added
+    - this includes adding the required parameters release, releaseplan, releaseplanadmission,
+      and releasestrategy as pipeline parameters
+    - a workspace is now mounted by the pipeline as required by this task
+- the snapshot parameter is now a namespaced name instead of a JSON string
+
+## Changes since 0.2
+- the verify_ec_task_bundle parameter was added
+    - with this addition, the verify-enterprise-contract task version is no longer static
+
+## Changes since 0.1
+
+The syntax for `taskRef.bundle` and `pipelineRef.bundle` is deprecated,
+bundles resolver is used with new format.

--- a/catalog/pipeline/deploy-release/0.6/README.md
+++ b/catalog/pipeline/deploy-release/0.6/README.md
@@ -14,6 +14,11 @@ Tekton pipeline to verify Snapshot prior to Deployment
 | enterpriseContractPolicy | JSON representation of the policy to be applied when validating the enterprise contract | No | - |
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
 
+## Changes since 0.5
+- use new version of collect-data task with subdirectory parameter
+- use PipelineRun UID for subdirectory inside the workspace
+    - this will avoid the issue of parallel PipelineRuns overriding each other's data
+
 ## Changes since 0.4
 - git resolvers are used in place of release bundle resolvers
 

--- a/catalog/pipeline/deploy-release/0.6/deploy-release.yaml
+++ b/catalog/pipeline/deploy-release/0.6/deploy-release.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: deploy-release
   labels:
-    app.kubernetes.io/version: "0.5"
+    app.kubernetes.io/version: "0.6"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -46,7 +46,7 @@ spec:
           - name: revision
             value: main
           - name: pathInRepo
-            value: catalog/task/collect-data/0.1/collect-data.yaml
+            value: catalog/task/collect-data/0.2/collect-data.yaml
       params:
         - name: release
           value: $(params.release)
@@ -58,6 +58,8 @@ spec:
           value: $(params.releasestrategy)
         - name: snapshot
           value: $(params.snapshot)
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
       workspaces:
         - name: data
           workspace: release-workspace
@@ -73,7 +75,7 @@ spec:
             value: verify-enterprise-contract
       params:
         - name: IMAGES
-          value: "$(workspaces.data.path)/snapshot_spec.json"
+          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/snapshot_spec.json"
         - name: SSL_CERT_DIR
           value: /var/run/secrets/kubernetes.io/serviceaccount
         - name: POLICY_CONFIGURATION

--- a/catalog/pipeline/deploy-release/0.6/deploy-release.yaml
+++ b/catalog/pipeline/deploy-release/0.6/deploy-release.yaml
@@ -34,6 +34,10 @@ spec:
     - name: verify_ec_task_bundle
       type: string
       description: The location of the bundle containing the verify-enterprise-contract task
+    - name: postCleanUp
+      type: string
+      description: Cleans up workspace after finishing executing the pipeline
+      default: "true"
   workspaces:
     - name: release-workspace
   tasks:
@@ -87,3 +91,24 @@ spec:
           workspace: release-workspace
       runAfter:
         - collect-data
+  finally:
+    - name: cleanup
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/cleanup-workspace/0.2/cleanup-workspace.yaml
+      when:
+        - input: $(params.postCleanUp)
+          operator: in
+          values: ["true"]
+      params:
+        - name: subdirectory
+          value: "$(context.pipelineRun.uid)"
+      workspaces:
+        - name: input
+          workspace: release-workspace

--- a/catalog/pipeline/deploy-release/0.6/deploy-release.yaml
+++ b/catalog/pipeline/deploy-release/0.6/deploy-release.yaml
@@ -1,0 +1,87 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: deploy-release
+  labels:
+    app.kubernetes.io/version: "0.5"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Tekton pipeline to verify Snapshot prior to Deployment
+  params:
+    - name: release
+      type: string
+      description:
+        The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution
+    - name: releaseplan
+      type: string
+      description: The namespaced name (namespace/name) of the releasePlan
+    - name: releaseplanadmission
+      type: string
+      description: The namespaced name (namespace/name) of the releasePlanAdmission
+    - name: releasestrategy
+      type: string
+      description: The namespaced name (namespace/name) of the releaseStrategy
+    - name: snapshot
+      type: string
+      description: The namespaced name (namespace/name) of the snapshot
+    - name: enterpriseContractPolicy
+      type: string
+      description: JSON representation of the EnterpriseContractPolicy
+    - name: verify_ec_task_bundle
+      type: string
+      description: The location of the bundle containing the verify-enterprise-contract task
+  workspaces:
+    - name: release-workspace
+  tasks:
+    - name: collect-data
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/collect-data/0.1/collect-data.yaml
+      params:
+        - name: release
+          value: $(params.release)
+        - name: releaseplan
+          value: $(params.releaseplan)
+        - name: releaseplanadmission
+          value: $(params.releaseplanadmission)
+        - name: releasestrategy
+          value: $(params.releasestrategy)
+        - name: snapshot
+          value: $(params.snapshot)
+      workspaces:
+        - name: data
+          workspace: release-workspace
+    - name: verify-enterprise-contract
+      taskRef:
+        resolver: "bundles"
+        params:
+          - name: bundle
+            value: $(params.verify_ec_task_bundle)
+          - name: kind
+            value: task
+          - name: name
+            value: verify-enterprise-contract
+      params:
+        - name: IMAGES
+          value: "$(workspaces.data.path)/snapshot_spec.json"
+        - name: SSL_CERT_DIR
+          value: /var/run/secrets/kubernetes.io/serviceaccount
+        - name: POLICY_CONFIGURATION
+          value: $(params.enterpriseContractPolicy)
+        - name: STRICT
+          value: "1"
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - collect-data

--- a/catalog/pipeline/deploy-release/0.6/samples/sample_release_PipelineRun.yaml
+++ b/catalog/pipeline/deploy-release/0.6/samples/sample_release_PipelineRun.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: release-run-empty-params
+spec:
+  params:
+    - name: release
+      value: ""
+    - name: releaseplan
+      value: ""
+    - name: releaseplanadmission
+      value: ""
+    - name: releasestrategy
+      value: ""
+    - name: snapshot
+      value: ""
+    - name: enterpriseContractPolicy
+      value: ""
+    - name: verify_ec_task_bundle
+      value: ""
+  pipelineRef:
+    resolver: "git"
+    params:
+      - name: url
+        value: https://github.com/redhat-appstudio/release-service-bundles.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: catalog/pipeline/deploy-release/0.5/deploy-release.yaml

--- a/catalog/pipeline/deploy-release/0.6/samples/sample_release_PipelineRun.yaml
+++ b/catalog/pipeline/deploy-release/0.6/samples/sample_release_PipelineRun.yaml
@@ -27,4 +27,4 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: catalog/pipeline/deploy-release/0.5/deploy-release.yaml
+        value: catalog/pipeline/deploy-release/0.6/deploy-release.yaml

--- a/catalog/pipeline/deploy-release/0.6/tests/run.yaml
+++ b/catalog/pipeline/deploy-release/0.6/tests/run.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: release-run-empty-params
+spec:
+  params:
+    - name: release
+      value: ""
+    - name: releaseplan
+      value: ""
+    - name: releaseplanadmission
+      value: ""
+    - name: releasestrategy
+      value: ""
+    - name: snapshot
+      value: ""
+    - name: enterpriseContractPolicy
+      value: ""
+    - name: verify_ec_task_bundle
+      value: ""
+  pipelineRef:
+    resolver: "git"
+    params:
+      - name: url
+        value: https://github.com/redhat-appstudio/release-service-bundles.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: catalog/pipeline/deploy-release/0.5/deploy-release.yaml

--- a/catalog/pipeline/deploy-release/0.6/tests/run.yaml
+++ b/catalog/pipeline/deploy-release/0.6/tests/run.yaml
@@ -27,4 +27,4 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: catalog/pipeline/deploy-release/0.5/deploy-release.yaml
+        value: catalog/pipeline/deploy-release/0.6/deploy-release.yaml

--- a/catalog/pipeline/fbc-release/0.18/README.md
+++ b/catalog/pipeline/fbc-release/0.18/README.md
@@ -31,6 +31,7 @@ Tekton release pipeline to interact with FBC Pipeline
 - use new version of collect-data task with subdirectory parameter
 - use PipelineRun UID for subdirectory inside the workspace
     - this will avoid the issue of parallel PipelineRuns overriding each other's data
+- use new version of create-internal-requests task with subdirectory parameter
 
 ### Changes since 0.16
 - git resolvers are used in place of release bundle resolvers

--- a/catalog/pipeline/fbc-release/0.18/README.md
+++ b/catalog/pipeline/fbc-release/0.18/README.md
@@ -27,6 +27,11 @@ Tekton release pipeline to interact with FBC Pipeline
 
 ## Changelog
 
+### Changes since 0.17
+- use new version of collect-data task with subdirectory parameter
+- use PipelineRun UID for subdirectory inside the workspace
+    - this will avoid the issue of parallel PipelineRuns overriding each other's data
+
 ### Changes since 0.16
 - git resolvers are used in place of release bundle resolvers
 

--- a/catalog/pipeline/fbc-release/0.18/README.md
+++ b/catalog/pipeline/fbc-release/0.18/README.md
@@ -1,0 +1,111 @@
+# FBC Release Pipeline
+
+Tekton release pipeline to interact with FBC Pipeline
+
+## Parameters
+
+| Name | Description | Optional | Default value |
+|------|-------------|----------|---------------|
+| release | The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution | No | - |
+| releaseplan | The namespaced name (namespace/name) of the releasePlan | No | - |
+| releaseplanadmission | The namespaced name (namespace/name) of the releasePlanAdmission | No | - |
+| releasestrategy | The namespaced name (namespace/name) of the releaseStrategy | No | - |
+| snapshot | The namespaced name (namespace/name) of the snapshot | No | - |
+| enterpriseContractPolicy | JSON representation of the EnterpriseContractPolicy | No | - |
+| fromIndex | The source Index image (catalog of catalogs) FBC fragment | No | - |
+| targetIndex | Index image (catalog of catalogs) the FBC fragment will be added to | No | - |
+| binaryImage | OCP binary image to be baked into the index image | Yes | "" |
+| buildTags | List of additional tags the internal index image copy should be tagged with | Yes | "[]" |
+| addArches | List of arches the index image should be built for | Yes | "[]" |
+| signingConfigMapName | The ConfigMap to be used by the signing Pipeline | Yes | "hacbs-signing-pipeline-config" |
+| iibServiceConfigSecret | Secret that contains IIB's service configuration | Yes | "iib-services-config" |
+| iibOverwriteFromIndexCredential | Secret that stores IIB's overwrite_from_index_token parameter value | Yes | "iib-overwrite-fromimage-credentials" |
+| fbcPublishingCredentials | Secret used to publish the built index image | Yes | "fbc-publishing-credentials" |
+| requestUpdateTimeout | Max seconds to wait until the status is updated | Yes | - |
+| buildTimeoutSeconds | Max seconds to wait until the build finishes | Yes | - |
+| verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
+
+## Changelog
+
+### Changes since 0.16
+- git resolvers are used in place of release bundle resolvers
+
+### Changes since 0.15
+- the collect-data task was added
+    - this includes adding the required parameters releaseplan, releaseplanadmission, and
+      releasestrategy as pipeline parameters
+- the snapshot parameter is now a namespaced name instead of a JSON string
+    - task versions were updated in accordance with this change
+
+### Changes since 0.14
+- adds parameters `iibServiceConfigSecret` and `iibOverwriteFromIndexCredential`
+  to enable the build of pre-GA and prod FBC components in the same namespace
+
+### Changes since 0.13
+- adds back the parameter `fbcPublishingCredentials` as different secrets
+  might be set for the same namespace
+
+### Changes since 0.12
+- the release parameter was added and the requester parameter was removed
+    - the value to use for signing is now pulled from the release resource status
+
+### Changes since 0.11
+- updates tasks that use `create-internal-request` task to 0.6 as now they need to
+  rely on its `genericResult` result
+- the task `publish-index-image` now uses `create-internal-request` so the publishing
+  is done by the cluster running the internal-services-controller
+- only executes `publish-index-image` and `sign-index-image` when genericResult result of
+  the tasks using `create-internal-request` has `fbc_opt_in=true` value set
+- removes `fbcPublishingCredentials` parameter
+- removes `overwriteFromIndex` parameter
+
+### Changes since 0.10
+- the verify_ec_task_bundle parameter was added
+    - with this addition, the verify-enterprise-contract task version is no longer static
+
+### Changes since 0.9
+- changes on the following tasks due to `create-internal-request` changes:
+    - `add-fbc-contribution-to-index-image` now accepts dynamic parameters
+    - `sign-index-image` now accepts dynamic parameters
+- changes on `publish-index-image` task to read data from its `inputDataFile` parameter
+- adds cleanup task
+
+### Changes since 0.8
+- fixes in the README.md file
+- adds param `fbcPublishingCredentials`
+- removes param `overwriteFromIndex`
+- adds new task `publish-index-image`
+
+### Changes since 0.7
+The syntax for `taskRef.bundle` and `pipelineRef.bundle` is deprecated,
+bundles resolver is used with new format.
+
+### Changes since 0.6
+- adds sign-index-image task
+- refactor task and change its reference name from `create-internal-request`
+  to `add-fbc-contribution-to-index-image`
+- adds `requester` and `signingConfigMapName` parameters
+- removes `resolvedIndexImage` result
+
+### Changes since 0.5
+- updates `create-internal-request` task version to 0.3
+
+### Changes since 0.4
+- updates `create-internal-request` task version to 0.2
+- adds `resolvedIndexImage` result
+
+### Changes since 0.3
+- removes param `fbcFragment`
+- adds param `buildTimeoutSeconds`
+
+### Changes since 0.2
+- renames the pipeline to `fbc-release`
+- forces the pipeline to run after `verify-enterprise-contract`
+
+### Changes since 0.1
+- adds param `requestUpdateTimeout`
+- adds task result values to the pipeline results
+  - `requestMessage` gets `$(tasks.create-internal-request.results.requestMessage)`
+  - `requestReason` gets `$(tasks.create-internal-request.results.requestReason)`
+  - `requestResults` gets `$(tasks.create-internal-request.results.requestResults)`
+- changes `verify-enterprise-contract` task version

--- a/catalog/pipeline/fbc-release/0.18/fbc-release.yaml
+++ b/catalog/pipeline/fbc-release/0.18/fbc-release.yaml
@@ -1,0 +1,288 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: fbc-release
+  labels:
+    app.kubernetes.io/version: "0.17"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Tekton release pipeline to interact with FBC Pipeline
+  params:
+    - name: release
+      type: string
+      description:
+        The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution
+    - name: releaseplan
+      type: string
+      description: The namespaced name (namespace/name) of the releasePlan
+    - name: releaseplanadmission
+      type: string
+      description: The namespaced name (namespace/name) of the releasePlanAdmission
+    - name: releasestrategy
+      type: string
+      description: The namespaced name (namespace/name) of the releaseStrategy
+    - name: snapshot
+      type: string
+      description: The namespaced name (namespace/name) of the snapshot
+    - name: enterpriseContractPolicy
+      type: string
+      description: JSON representation of the EnterpriseContractPolicy
+    - name: fromIndex
+      type: string
+      description: The source Index image (catalog of catalogs) FBC fragment
+    - name: targetIndex
+      type: string
+      description: Index image (catalog of catalogs) the FBC fragment will be added to
+    - name: binaryImage
+      type: string
+      default: ""
+      description: OCP binary image to be baked into the index image
+    - name: buildTags
+      type: string
+      default: "[]"
+      description: List of additional tags the internal index image copy should be tagged with
+    - name: addArches
+      type: string
+      default: "[]"
+      description: List of arches the index image should be built for
+    - name: signingConfigMapName
+      type: string
+      default: "hacbs-signing-pipeline-config"
+      description: The ConfigMap to be used by the signing Pipeline
+    - name: iibServiceConfigSecret
+      default: "iib-services-config"
+      type: string
+      description: Secret that contains IIB's service configuration
+    - name: iibOverwriteFromIndexCredential
+      default: "iib-overwrite-fromimage-credentials"
+      type: string
+      description: Secret that stores IIB's overwrite_from_index_token parameter value
+    - name: fbcPublishingCredentials
+      type: string
+      default: "fbc-publishing-credentials"
+      description: Secret used to publish the built index image
+    - name: requestUpdateTimeout
+      type: string
+      description: Max seconds to wait until the status is updated
+    - name: buildTimeoutSeconds
+      type: string
+      description: Max seconds to wait until the build finishes
+    - name: verify_ec_task_bundle
+      type: string
+      description: The location of the bundle containing the verify-enterprise-contract task
+  workspaces:
+    - name: release-workspace
+  results:
+    - name: requestMessage
+      value: $(tasks.add-fbc-contribution-to-index-image.results.requestMessage)
+    - name: requestReason
+      value: $(tasks.add-fbc-contribution-to-index-image.results.requestReason)
+  tasks:
+    - name: collect-data
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/collect-data/0.1/collect-data.yaml
+      params:
+        - name: release
+          value: $(params.release)
+        - name: releaseplan
+          value: $(params.releaseplan)
+        - name: releaseplanadmission
+          value: $(params.releaseplanadmission)
+        - name: releasestrategy
+          value: $(params.releasestrategy)
+        - name: snapshot
+          value: $(params.snapshot)
+      workspaces:
+        - name: data
+          workspace: release-workspace
+    - name: verify-enterprise-contract
+      taskRef:
+        resolver: "bundles"
+        params:
+          - name: bundle
+            value: $(params.verify_ec_task_bundle)
+          - name: kind
+            value: task
+          - name: name
+            value: verify-enterprise-contract
+      params:
+        - name: IMAGES
+          value: "$(workspaces.data.path)/snapshot_spec.json"
+        - name: SSL_CERT_DIR
+          value: /var/run/secrets/kubernetes.io/serviceaccount
+        - name: POLICY_CONFIGURATION
+          value: $(params.enterpriseContractPolicy)
+        - name: STRICT
+          value: "1"
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - collect-data
+    - name: add-fbc-contribution-to-index-image
+      workspaces:
+        - name: input
+          workspace: release-workspace
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/create-internal-request/0.6/create-internal-request.yaml
+      params:
+        - name: pipelineRunName
+          value: $(context.pipelineRun.name)
+        - name: request
+          value: "iib"
+        - name: updateGenericResult
+          value: "true"
+        - name: params
+          value:
+            - name: binaryImage
+              value: "$(params.binaryImage)"
+            - name: fromIndex
+              value: "$(params.fromIndex)"
+            - name: buildTags
+              value: "$(params.buildTags)"
+            - name: addArches
+              value: "$(params.addArches)"
+            - name: buildTimeoutSeconds
+              value: "$(params.buildTimeoutSeconds)"
+            - name: iibServiceConfigSecret
+              value: "$(params.iibServiceConfigSecret)"
+            - name: iibOverwriteFromIndexCredential
+              value: "$(params.iibOverwriteFromIndexCredential)"
+            - name: fbcFragment
+              value: "$(tasks.collect-data.results.fbcFragment)"
+      runAfter:
+        - verify-enterprise-contract
+    - name: extract-requester-from-release
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/upstream/tekton/kubernetes-actions/0.2/kubernetes-actions.yaml
+      params:
+        - name: image
+          value: "quay.io/hacbs-release/cloud-builders-kubectl\
+            @sha256:8ab94be8b2b4f3d117f02d868b39540fddd225447abf4014f7ba4765cb39f753"
+        - name: script
+          value: |
+            set -x
+
+            NAMESPACE=$(echo $(params.release) | cut -d '/' -f 1)
+            NAME=$(echo $(params.release) | cut -d '/' -f 2)
+
+            AUTHOR=$(kubectl get release ${NAME} -n ${NAMESPACE} \
+            -o=jsonpath='{.status.attribution.author}' | tee $(results.output-result.path))
+
+            if [[ ${AUTHOR} == "" ]] ; then exit 1 ; fi
+    - name: sign-index-image
+      workspaces:
+        - name: input
+          workspace: release-workspace
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/create-internal-request/0.6/create-internal-request.yaml
+      params:
+        - name: pipelineRunName
+          value: $(context.pipelineRun.name)
+        - name: inputDataFile
+          value: $(tasks.add-fbc-contribution-to-index-image.results.requestResultsFile)
+        - name: request
+          value: "hacbs-signing-pipeline"
+        - name: params
+          value:
+            - name: manifest_digest
+              value: "sharedRequestFile:json:.jsonBuildInfo"
+              jsonKey: ".index_image_resolved"
+            - name: pipeline_image
+              value: "quay.io/redhat-isv/operator-pipelines-images:released"
+            - name: reference
+              value: $(params.targetIndex)
+            - name: requester
+              value: $(tasks.extract-requester-from-release.results.output-result)
+            - name: config_map_name
+              value: $(params.signingConfigMapName)
+      when:
+        - input: "$(tasks.add-fbc-contribution-to-index-image.results.genericResult)"
+          operator: in
+          values: ["fbc_opt_in=true"]
+    - name: publish-index-image
+      workspaces:
+        - name: input
+          workspace: release-workspace
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/create-internal-request/0.6/create-internal-request.yaml
+      params:
+        - name: pipelineRunName
+          value: $(context.pipelineRun.name)
+        - name: inputDataFile
+          value: $(tasks.add-fbc-contribution-to-index-image.results.requestResultsFile)
+        - name: request
+          value: "publish-index-image-pipeline"
+        - name: params
+          value:
+            - name: sourceIndex
+              value: "sharedRequestFile:json:.jsonBuildInfo"
+              jsonKey: ".index_image_resolved"
+            - name: targetIndex
+              value: $(params.targetIndex)
+            - name: publishingCredentials
+              value: $(params.fbcPublishingCredentials)
+            - name: retries
+              value: "0"
+      when:
+        - input: "$(tasks.add-fbc-contribution-to-index-image.results.genericResult)"
+          operator: in
+          values: ["fbc_opt_in=true"]
+      runAfter:
+        - sign-index-image
+  finally:
+    - name: cleanup
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/cleanup-workspace/0.2/cleanup-workspace.yaml
+      params:
+        - name: subdirectory
+          value: "internal-request"
+      workspaces:
+        - name: input
+          workspace: release-workspace

--- a/catalog/pipeline/fbc-release/0.18/fbc-release.yaml
+++ b/catalog/pipeline/fbc-release/0.18/fbc-release.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: fbc-release
   labels:
-    app.kubernetes.io/version: "0.17"
+    app.kubernetes.io/version: "0.18"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -91,7 +91,7 @@ spec:
           - name: revision
             value: main
           - name: pathInRepo
-            value: catalog/task/collect-data/0.1/collect-data.yaml
+            value: catalog/task/collect-data/0.2/collect-data.yaml
       params:
         - name: release
           value: $(params.release)
@@ -103,6 +103,8 @@ spec:
           value: $(params.releasestrategy)
         - name: snapshot
           value: $(params.snapshot)
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
       workspaces:
         - name: data
           workspace: release-workspace
@@ -118,7 +120,7 @@ spec:
             value: verify-enterprise-contract
       params:
         - name: IMAGES
-          value: "$(workspaces.data.path)/snapshot_spec.json"
+          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/snapshot_spec.json"
         - name: SSL_CERT_DIR
           value: /var/run/secrets/kubernetes.io/serviceaccount
         - name: POLICY_CONFIGURATION

--- a/catalog/pipeline/fbc-release/0.18/fbc-release.yaml
+++ b/catalog/pipeline/fbc-release/0.18/fbc-release.yaml
@@ -148,7 +148,7 @@ spec:
           - name: revision
             value: main
           - name: pathInRepo
-            value: catalog/task/create-internal-request/0.6/create-internal-request.yaml
+            value: catalog/task/create-internal-request/0.7/create-internal-request.yaml
       params:
         - name: pipelineRunName
           value: $(context.pipelineRun.name)
@@ -156,6 +156,8 @@ spec:
           value: "iib"
         - name: updateGenericResult
           value: "true"
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
         - name: params
           value:
             - name: binaryImage
@@ -213,7 +215,7 @@ spec:
           - name: revision
             value: main
           - name: pathInRepo
-            value: catalog/task/create-internal-request/0.6/create-internal-request.yaml
+            value: catalog/task/create-internal-request/0.7/create-internal-request.yaml
       params:
         - name: pipelineRunName
           value: $(context.pipelineRun.name)
@@ -221,6 +223,8 @@ spec:
           value: $(tasks.add-fbc-contribution-to-index-image.results.requestResultsFile)
         - name: request
           value: "hacbs-signing-pipeline"
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
         - name: params
           value:
             - name: manifest_digest
@@ -250,7 +254,7 @@ spec:
           - name: revision
             value: main
           - name: pathInRepo
-            value: catalog/task/create-internal-request/0.6/create-internal-request.yaml
+            value: catalog/task/create-internal-request/0.7/create-internal-request.yaml
       params:
         - name: pipelineRunName
           value: $(context.pipelineRun.name)
@@ -258,6 +262,8 @@ spec:
           value: $(tasks.add-fbc-contribution-to-index-image.results.requestResultsFile)
         - name: request
           value: "publish-index-image-pipeline"
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
         - name: params
           value:
             - name: sourceIndex
@@ -276,23 +282,7 @@ spec:
       runAfter:
         - sign-index-image
   finally:
-    - name: cleanup-internal-request
-      taskRef:
-        resolver: "git"
-        params:
-          - name: url
-            value: https://github.com/redhat-appstudio/release-service-bundles.git
-          - name: revision
-            value: main
-          - name: pathInRepo
-            value: catalog/task/cleanup-workspace/0.2/cleanup-workspace.yaml
-      params:
-        - name: subdirectory
-          value: "internal-request"
-      workspaces:
-        - name: input
-          workspace: release-workspace
-    - name: cleanup-subdirectory
+    - name: cleanup
       taskRef:
         resolver: "git"
         params:

--- a/catalog/pipeline/fbc-release/0.18/fbc-release.yaml
+++ b/catalog/pipeline/fbc-release/0.18/fbc-release.yaml
@@ -74,6 +74,10 @@ spec:
     - name: verify_ec_task_bundle
       type: string
       description: The location of the bundle containing the verify-enterprise-contract task
+    - name: postCleanUp
+      type: string
+      description: Cleans up workspace after finishing executing the pipeline
+      default: "true"
   workspaces:
     - name: release-workspace
   results:
@@ -272,7 +276,7 @@ spec:
       runAfter:
         - sign-index-image
   finally:
-    - name: cleanup
+    - name: cleanup-internal-request
       taskRef:
         resolver: "git"
         params:
@@ -285,6 +289,26 @@ spec:
       params:
         - name: subdirectory
           value: "internal-request"
+      workspaces:
+        - name: input
+          workspace: release-workspace
+    - name: cleanup-subdirectory
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/cleanup-workspace/0.2/cleanup-workspace.yaml
+      when:
+        - input: $(params.postCleanUp)
+          operator: in
+          values: ["true"]
+      params:
+        - name: subdirectory
+          value: "$(context.pipelineRun.uid)"
       workspaces:
         - name: input
           workspace: release-workspace

--- a/catalog/pipeline/fbc-release/0.18/samples/sample_release_PipelineRun.yaml
+++ b/catalog/pipeline/fbc-release/0.18/samples/sample_release_PipelineRun.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: fbc-release-run-empty-params
+spec:
+  params:
+    - name: release
+      value: ""
+    - name: releaseplan
+      value: ""
+    - name: releaseplanadmission
+      value: ""
+    - name: releasestrategy
+      value: ""
+    - name: snapshot
+      value: ""
+    - name: enterpriseContractPolicy
+      value: ""
+    - name: release
+      value: ""
+    - name: fromIndex
+      value: ""
+    - name: targetIndex
+      value: ""
+    - name: binaryImage
+      value: ""
+    - name: buildTags
+      value: ""
+    - name: addArches
+      value: ""
+    - name: signingConfigMapName
+      value: ""
+    - name: iibServiceConfigSecret
+      value: ""
+    - name: iibOverwriteFromIndexCredential
+      value: ""
+    - name: fbcPublishingCredentials
+      value: ""
+    - name: requestUpdateTimeout
+      value: ""
+    - name: buildTimeoutSeconds
+      value: ""
+    - name: verify_ec_task_bundle
+      value: ""
+  pipelineRef:
+    resolver: "git"
+    params:
+      - name: url
+        value: https://github.com/redhat-appstudio/release-service-bundles.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: catalog/pipeline/fbc-release/0.17/fbc-release.yaml

--- a/catalog/pipeline/fbc-release/0.18/samples/sample_release_PipelineRun.yaml
+++ b/catalog/pipeline/fbc-release/0.18/samples/sample_release_PipelineRun.yaml
@@ -51,4 +51,4 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: catalog/pipeline/fbc-release/0.17/fbc-release.yaml
+        value: catalog/pipeline/fbc-release/0.18/fbc-release.yaml

--- a/catalog/pipeline/fbc-release/0.18/tests/run.yaml
+++ b/catalog/pipeline/fbc-release/0.18/tests/run.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: fbc-release-run-empty-params
+spec:
+  params:
+    - name: release
+      value: ""
+    - name: releaseplan
+      value: ""
+    - name: releaseplanadmission
+      value: ""
+    - name: releasestrategy
+      value: ""
+    - name: snapshot
+      value: ""
+    - name: enterpriseContractPolicy
+      value: ""
+    - name: release
+      value: ""
+    - name: fromIndex
+      value: ""
+    - name: targetIndex
+      value: ""
+    - name: binaryImage
+      value: ""
+    - name: buildTags
+      value: ""
+    - name: addArches
+      value: ""
+    - name: signingConfigMapName
+      value: ""
+    - name: iibServiceConfigSecret
+      value: ""
+    - name: iibOverwriteFromIndexCredential
+      value: ""
+    - name: fbcPublishingCredentials
+      value: ""
+    - name: requestUpdateTimeout
+      value: ""
+    - name: buildTimeoutSeconds
+      value: ""
+    - name: verify_ec_task_bundle
+      value: ""
+  pipelineRef:
+    resolver: "git"
+    params:
+      - name: url
+        value: https://github.com/redhat-appstudio/release-service-bundles.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: catalog/pipeline/fbc-release/0.17/fbc-release.yaml

--- a/catalog/pipeline/fbc-release/0.18/tests/run.yaml
+++ b/catalog/pipeline/fbc-release/0.18/tests/run.yaml
@@ -51,4 +51,4 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: catalog/pipeline/fbc-release/0.17/fbc-release.yaml
+        value: catalog/pipeline/fbc-release/0.18/fbc-release.yaml

--- a/catalog/pipeline/push-to-external-registry/0.16/README.md
+++ b/catalog/pipeline/push-to-external-registry/0.16/README.md
@@ -1,0 +1,85 @@
+# Push to External Registry Pipeline
+
+Tekton pipeline to push images to an external registry.
+
+## Parameters
+
+| Name | Description | Optional | Default value |
+|------|-------------|----------|---------------|
+| release | The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution | No | - |
+| releaseplan | The namespaced name (namespace/name) of the releasePlan | No | - |
+| releaseplanadmission | The namespaced name (namespace/name) of the releasePlanAdmission | No | - |
+| releasestrategy | The namespaced name (namespace/name) of the releaseStrategy | No | - |
+| snapshot | The namespaced name (namespace/name) of the snapshot | No | - |
+| enterpriseContractPolicy | JSON representation of the policy to be applied when validating the enterprise contract | No | - |
+| extraConfigGitUrl |URL to the remote Git repository containing the extra config | No | - |
+| extraConfigGitRevision | Revision to fetch from the remote Git repository containing the extra config | No | - |
+| extraConfigPath | Path to the extra config file within the repository | No | - |
+| tag | The default tag to use when mapping file does not contain a tag | No | - |
+| addGitShaTag | When pushing the snapshot components, also push a tag with the image git sha | Yes | true |
+| addSourceShaTag | When pushing the snapshot components, also push a tag with the image source sha | Yes | true |
+| addTimestampTag | When pushing the snapshot components, also push a tag with the current timestamp | Yes | false |
+| pyxisServerType | The Pyxis server type to use. Options are 'production' and 'stage' | No | - |
+| pyxisSecret | The kubernetes secret to use to authenticate to Pyxis. It needs to contain two keys: key and cert | No | - |
+| postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
+| verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
+
+## Changes since 0.14
+* update push-snapshot task to be v0.10
+
+## Changes since 0.13
+* git resolvers are used in place of release bundle resolvers
+
+## Changes since 0.12
+* the push-snapshot task was updated to version 0.9 to use `cosign copy` instead of `skopeo copy`
+
+## Changes since 0.11
+* the collect-data task was added
+  * this includes adding the required parameters release, releaseplan, releaseplanadmission,
+      and releasestrategy as pipeline parameters
+* the snapshot parameter is now a namespaced name instead of a JSON string
+  * task versions were updated in accordance with this change
+
+## Changes since 0.10
+* the verify_ec_task_bundle parameter was added
+  * with this addition, the verify-enterprise-contract task version is no longer static
+
+## Changes since 0.9
+* addGitShaTag now defaults to true instead of false
+
+## Changes since 0.8
+* Use version 0.4 of apply-mapping task and set the new failOnEmptyResult parameter to true
+  * This will ensure that if the result of mapping is an empty component list, the task will fail
+
+## Changes since 0.7
+* Upgrade push-snapshot task to version 0.7
+  * Only the first 7 characters are used for the git sha tag in Quay.
+
+## Changes since 0.6
+Add `push-sbom-to-pyxis` task to the pipeline. This will ensure that sbom components
+for the image are pushed to Pyxis as part of this pipeline.
+
+## Changes since 0.5
+The syntax for `taskRef.bundle` and `pipelineRef.bundle` is deprecated,
+bundles resolver is used with new format.
+
+## Changes since 0.4
+* Upgrade push-snapshot task to version 0.6
+  * addShaTag parameter is now named addSourceShaTag
+  * addGitShaTag parameter is now supported and passed as a pipeline parameter to the task
+
+## Changes since 0.3
+
+* Upgrade push-snapshot task to version 0.5
+  * addShaTag parameter is now supported and passed as a pipeline parameter to the task
+  * addTimestampTag parameter is now supported and passed as a pipeline parameter to the task
+
+## Changes since 0.2
+
+* push-snapshot now supports tag parameter
+
+## Changes since 0.1
+
+* Upgrade create-pyxis-image task to version 0.2
+  * correct incorrect snapshot param
+

--- a/catalog/pipeline/push-to-external-registry/0.16/README.md
+++ b/catalog/pipeline/push-to-external-registry/0.16/README.md
@@ -24,6 +24,12 @@ Tekton pipeline to push images to an external registry.
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
 
+## Changes since 0.15
+- use new version of collect-data task with subdirectory parameter
+- use PipelineRun UID for subdirectory inside the workspace
+    - this will avoid the issue of parallel PipelineRuns overriding each other's data
+- also use new version of apply-mapping which overrides the original snapshot_spec file
+
 ## Changes since 0.14
 * update push-snapshot task to be v0.10
 

--- a/catalog/pipeline/push-to-external-registry/0.16/README.md
+++ b/catalog/pipeline/push-to-external-registry/0.16/README.md
@@ -29,6 +29,7 @@ Tekton pipeline to push images to an external registry.
 - use PipelineRun UID for subdirectory inside the workspace
     - this will avoid the issue of parallel PipelineRuns overriding each other's data
 - also use new version of apply-mapping which overrides the original snapshot_spec file
+    - and specify snapshotPath for this task to point to the subdir
 
 ## Changes since 0.14
 * update push-snapshot task to be v0.10

--- a/catalog/pipeline/push-to-external-registry/0.16/push-to-external-registry.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.16/push-to-external-registry.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: push-to-external-registry
   labels:
-    app.kubernetes.io/version: "0.15"
+    app.kubernetes.io/version: "0.16"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -84,7 +84,7 @@ spec:
           - name: revision
             value: main
           - name: pathInRepo
-            value: catalog/task/collect-data/0.1/collect-data.yaml
+            value: catalog/task/collect-data/0.2/collect-data.yaml
       params:
         - name: release
           value: $(params.release)
@@ -96,6 +96,8 @@ spec:
           value: $(params.releasestrategy)
         - name: snapshot
           value: $(params.snapshot)
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
       workspaces:
         - name: data
           workspace: release-workspace
@@ -119,7 +121,7 @@ spec:
         - name: revision
           value: $(params.extraConfigGitRevision)
         - name: subdirectory
-          value: "$(context.pipelineRun.uid)"
+          value: "$(context.pipelineRun.uid)/extraConfig"
       workspaces:
         - name: output
           workspace: release-workspace
@@ -132,10 +134,10 @@ spec:
           - name: revision
             value: main
           - name: pathInRepo
-            value: catalog/task/apply-mapping/0.5/apply-mapping.yaml
+            value: catalog/task/apply-mapping/0.6/apply-mapping.yaml
       params:
         - name: extraConfigPath
-          value: "$(context.pipelineRun.uid)/$(params.extraConfigPath)"
+          value: "$(context.pipelineRun.uid)/extraConfig/$(params.extraConfigPath)"
         - name: failOnEmptyResult
           value: "true"
       when:
@@ -159,7 +161,7 @@ spec:
             value: verify-enterprise-contract
       params:
         - name: IMAGES
-          value: "$(workspaces.data.path)/mapped_snapshot.json"
+          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/snapshot_spec.json"
         - name: SSL_CERT_DIR
           value: /var/run/secrets/kubernetes.io/serviceaccount
         - name: POLICY_CONFIGURATION
@@ -190,6 +192,8 @@ spec:
           value: $(params.addSourceShaTag)
         - name: addTimestampTag
           value: $(params.addTimestampTag)
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot_spec.json"
       workspaces:
         - name: data
           workspace: release-workspace
@@ -212,6 +216,8 @@ spec:
           value: $(params.pyxisSecret)
         - name: tag
           value: $(params.tag)
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot_spec.json"
       workspaces:
         - name: data
           workspace: release-workspace
@@ -234,6 +240,8 @@ spec:
           value: $(params.pyxisServerType)
         - name: pyxisSecret
           value: $(params.pyxisSecret)
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot_spec.json"
       workspaces:
         - name: data
           workspace: release-workspace

--- a/catalog/pipeline/push-to-external-registry/0.16/push-to-external-registry.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.16/push-to-external-registry.yaml
@@ -1,0 +1,263 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: push-to-external-registry
+  labels:
+    app.kubernetes.io/version: "0.15"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Tekton pipeline to release HACBS Snapshot to Quay
+  params:
+    - name: release
+      type: string
+      description:
+        The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution
+    - name: releaseplan
+      type: string
+      description: The namespaced name (namespace/name) of the releasePlan
+    - name: releaseplanadmission
+      type: string
+      description: The namespaced name (namespace/name) of the releasePlanAdmission
+    - name: releasestrategy
+      type: string
+      description: The namespaced name (namespace/name) of the releaseStrategy
+    - name: snapshot
+      type: string
+      description: The namespaced name (namespace/name) of the snapshot
+    - name: enterpriseContractPolicy
+      type: string
+      description: JSON representation of the EnterpriseContractPolicy
+    - name: extraConfigGitUrl
+      type: string
+      description: URL to the remote Git repository containing the extra config
+      default: ""
+    - name: extraConfigGitRevision
+      type: string
+      description: Revision to fetch from the remote Git repository containing the extra config
+      default: ""
+    - name: extraConfigPath
+      type: string
+      description: Path to the extra config file within the repository
+      default: ""
+    - name: tag
+      type: string
+      description: The default tag to use when mapping file does not contain a tag
+    - name: addGitShaTag
+      type: string
+      description: When pushing the snapshot components, also push a tag with the image git sha
+      default: "true"
+    - name: addSourceShaTag
+      type: string
+      description: When pushing the snapshot components, also push a tag with the image source sha
+      default: "true"
+    - name: addTimestampTag
+      type: string
+      description: When pushing the snapshot components, also push a tag with the current timestamp
+      default: "false"
+    - name: pyxisServerType
+      type: string
+      description: The Pyxis server type to use. Options are 'production' and 'stage'
+    - name: pyxisSecret
+      type: string
+      description: |
+        The kubernetes secret to use to authenticate to Pyxis. It needs to contain two keys: key and cert
+    - name: postCleanUp
+      type: string
+      description: Cleans up workspace after finishing executing the pipeline
+      default: "true"
+    - name: verify_ec_task_bundle
+      type: string
+      description: The location of the bundle containing the verify-enterprise-contract task
+  workspaces:
+    - name: release-workspace
+  tasks:
+    - name: collect-data
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/collect-data/0.1/collect-data.yaml
+      params:
+        - name: release
+          value: $(params.release)
+        - name: releaseplan
+          value: $(params.releaseplan)
+        - name: releaseplanadmission
+          value: $(params.releaseplanadmission)
+        - name: releasestrategy
+          value: $(params.releasestrategy)
+        - name: snapshot
+          value: $(params.snapshot)
+      workspaces:
+        - name: data
+          workspace: release-workspace
+    - name: clone-config-file
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/build-definitions.git
+          - name: revision
+            value: dedce1f59906394ea777606683eec9eb2de465ac
+          - name: pathInRepo
+            value: task/git-clone/0.1/git-clone.yaml
+      when:
+        - input: $(params.extraConfigGitUrl)
+          operator: notin
+          values: [""]
+      params:
+        - name: url
+          value: $(params.extraConfigGitUrl)
+        - name: revision
+          value: $(params.extraConfigGitRevision)
+        - name: subdirectory
+          value: "$(context.pipelineRun.uid)"
+      workspaces:
+        - name: output
+          workspace: release-workspace
+    - name: apply-mapping
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/apply-mapping/0.5/apply-mapping.yaml
+      params:
+        - name: extraConfigPath
+          value: "$(context.pipelineRun.uid)/$(params.extraConfigPath)"
+        - name: failOnEmptyResult
+          value: "true"
+      when:
+        - input: $(tasks.clone-config-file.results.commit)
+          operator: notin
+          values: [""]
+      workspaces:
+        - name: config
+          workspace: release-workspace
+      runAfter:
+        - collect-data
+    - name: verify-enterprise-contract
+      taskRef:
+        resolver: "bundles"
+        params:
+          - name: bundle
+            value: $(params.verify_ec_task_bundle)
+          - name: kind
+            value: task
+          - name: name
+            value: verify-enterprise-contract
+      params:
+        - name: IMAGES
+          value: "$(workspaces.data.path)/mapped_snapshot.json"
+        - name: SSL_CERT_DIR
+          value: /var/run/secrets/kubernetes.io/serviceaccount
+        - name: POLICY_CONFIGURATION
+          value: $(params.enterpriseContractPolicy)
+        - name: STRICT
+          value: "1"
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - apply-mapping
+    - name: push-snapshot
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/push-snapshot/0.10/push-snapshot.yaml
+      params:
+        - name: tag
+          value: $(params.tag)
+        - name: addGitShaTag
+          value: $(params.addGitShaTag)
+        - name: addSourceShaTag
+          value: $(params.addSourceShaTag)
+        - name: addTimestampTag
+          value: $(params.addTimestampTag)
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - verify-enterprise-contract
+    - name: create-pyxis-image
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/create-pyxis-image/0.4/create-pyxis-image.yaml
+      params:
+        - name: server
+          value: $(params.pyxisServerType)
+        - name: pyxisSecret
+          value: $(params.pyxisSecret)
+        - name: tag
+          value: $(params.tag)
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - push-snapshot
+    - name: push-sbom-to-pyxis
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/push-sbom-to-pyxis/0.2/push-sbom-to-pyxis.yaml
+      params:
+        - name: containerImageIDs
+          value: $(tasks.create-pyxis-image.results.containerImageIDs)
+        - name: server
+          value: $(params.pyxisServerType)
+        - name: pyxisSecret
+          value: $(params.pyxisSecret)
+      workspaces:
+        - name: data
+          workspace: release-workspace
+  finally:
+    - name: cleanup
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/cleanup-workspace/0.2/cleanup-workspace.yaml
+      when:
+        - input: $(params.postCleanUp)
+          operator: in
+          values: ["true"]
+        - input: $(params.extraConfigGitUrl)
+          operator: notin
+          values: [""]
+      params:
+        - name: subdirectory
+          value: "$(context.pipelineRun.uid)"
+      workspaces:
+        - name: input
+          workspace: release-workspace

--- a/catalog/pipeline/push-to-external-registry/0.16/push-to-external-registry.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.16/push-to-external-registry.yaml
@@ -260,9 +260,6 @@ spec:
         - input: $(params.postCleanUp)
           operator: in
           values: ["true"]
-        - input: $(params.extraConfigGitUrl)
-          operator: notin
-          values: [""]
       params:
         - name: subdirectory
           value: "$(context.pipelineRun.uid)"

--- a/catalog/pipeline/push-to-external-registry/0.16/push-to-external-registry.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.16/push-to-external-registry.yaml
@@ -140,6 +140,8 @@ spec:
           value: "$(context.pipelineRun.uid)/extraConfig/$(params.extraConfigPath)"
         - name: failOnEmptyResult
           value: "true"
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot_spec.json"
       when:
         - input: $(tasks.clone-config-file.results.commit)
           operator: notin

--- a/catalog/pipeline/push-to-external-registry/0.16/samples/sample_push-to-external-registry_PipelineRun.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.16/samples/sample_push-to-external-registry_PipelineRun.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: push-to-external-registry-run-empty-params
+spec:
+  params:
+    - name: release
+      value: ""
+    - name: releaseplan
+      value: ""
+    - name: releaseplanadmission
+      value: ""
+    - name: releasestrategy
+      value: ""
+    - name: snapshot
+      value: ""
+    - name: enterpriseContractPolicy
+      value: ""
+    - name: extraConfigGitUrl
+      value: ""
+    - name: extraConfigGitRevision
+      value: ""
+    - name: extraConfigPath
+      value: ""
+    - name: pyxisServerType
+      value: ""
+    - name: pyxisSecret
+      value: ""
+    - name: tag
+      value: ""
+    - name: postCleanUp
+      value: ""
+    - name: verify_ec_task_bundle
+      value: ""
+  pipelineRef:
+    resolver: "git"
+    params:
+      - name: url
+        value: https://github.com/redhat-appstudio/release-service-bundles.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: catalog/pipeline/push-to-external-registry/0.15/push-to-external-registry.yaml

--- a/catalog/pipeline/push-to-external-registry/0.16/samples/sample_push-to-external-registry_PipelineRun.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.16/samples/sample_push-to-external-registry_PipelineRun.yaml
@@ -41,4 +41,4 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: catalog/pipeline/push-to-external-registry/0.15/push-to-external-registry.yaml
+        value: catalog/pipeline/push-to-external-registry/0.16/push-to-external-registry.yaml

--- a/catalog/pipeline/push-to-external-registry/0.16/tests/run.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.16/tests/run.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: push-to-external-registry-run-empty-params
+spec:
+  params:
+    - name: release
+      value: ""
+    - name: releaseplan
+      value: ""
+    - name: releaseplanadmission
+      value: ""
+    - name: releasestrategy
+      value: ""
+    - name: snapshot
+      value: ""
+    - name: enterpriseContractPolicy
+      value: ""
+    - name: extraConfigGitUrl
+      value: ""
+    - name: extraConfigGitRevision
+      value: ""
+    - name: extraConfigPath
+      value: ""
+    - name: pyxisServerType
+      value: ""
+    - name: pyxisSecret
+      value: ""
+    - name: tag
+      value: ""
+    - name: postCleanUp
+      value: ""
+    - name: verify_ec_task_bundle
+      value: ""
+  pipelineRef:
+    resolver: "git"
+    params:
+      - name: url
+        value: https://github.com/redhat-appstudio/release-service-bundles.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: catalog/pipeline/push-to-external-registry/0.15/push-to-external-registry.yaml

--- a/catalog/pipeline/push-to-external-registry/0.16/tests/run.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.16/tests/run.yaml
@@ -41,4 +41,4 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: catalog/pipeline/push-to-external-registry/0.15/push-to-external-registry.yaml
+        value: catalog/pipeline/push-to-external-registry/0.16/push-to-external-registry.yaml

--- a/catalog/pipeline/release/0.18/README.md
+++ b/catalog/pipeline/release/0.18/README.md
@@ -19,6 +19,12 @@ Tekton pipeline to release Stonesoup Snapshot to Quay.
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
 
+## Changes since 0.17
+* use new version of collect-data task with subdirectory parameter
+* use PipelineRun UID for subdirectory inside the workspace
+    * this will avoid the issue of parallel PipelineRuns overriding each other's data
+* also use new version of apply-mapping which overrides the original snapshot_spec file
+
 ## Changes since 0.16
 * git resolvers are used in place of release bundle resolvers
 

--- a/catalog/pipeline/release/0.18/README.md
+++ b/catalog/pipeline/release/0.18/README.md
@@ -1,0 +1,120 @@
+# Release Pipeline
+
+Tekton pipeline to release Stonesoup Snapshot to Quay.
+
+## Parameters
+
+| Name | Description | Optional | Default value |
+|------|-------------|----------|---------------|
+| release | The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution | No | - |
+| releaseplan | The namespaced name (namespace/name) of the releasePlan | No | - |
+| releaseplanadmission | The namespaced name (namespace/name) of the releasePlanAdmission | No | - |
+| releasestrategy | The namespaced name (namespace/name) of the releaseStrategy | No | - |
+| snapshot | The namespaced name (namespace/name) of the snapshot | No | - |
+| enterpriseContractPolicy | JSON representation of the policy to be applied when validating the enterprise contract | No | - |
+| extraConfigGitUrl |URL to the remote Git repository containing the extra config | No | - |
+| extraConfigGitRevision | Revision to fetch from the remote Git repository containing the extra config | No | - |
+| extraConfigPath | Path to the extra config file within the repository | No | - |
+| addGitShaTag | When pushing the snapshot components, also push a tag with the image git sha | Yes | true |
+| postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
+| verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
+
+## Changes since 0.16
+* git resolvers are used in place of release bundle resolvers
+
+## Changes since 0.15
+* the push-snapshot task was updated to version 0.9 to use `cosign copy` instead of `skopeo copy`
+
+## Changes since 0.14
+* the collect-data task was added
+  * this includes adding the required parameters release, releaseplan, releaseplanadmission,
+      and releasestrategy as pipeline parameters
+* the snapshot parameter is now a namespaced name instead of a JSON string
+  * task versions were updated in accordance with this change
+
+## Changes since 0.13
+* the verify_ec_task_bundle parameter was added
+  * with this addition, the verify-enterprise-contract task version is no longer static
+
+## Changes since 0.12
+* addGitShaTag now defaults to true instead of false
+
+## Changes since 0.11
+* Use version 0.4 of apply-mapping task and set the new failOnEmptyResult parameter to true
+  * This will ensure that if the result of mapping is an empty component list, the task will fail
+
+## Changes since 0.10
+
+Update tag of ec-task-bundle task
+
+## Changes since 0.9
+
+* The syntax for `taskRef.bundle` and `pipelineRef.bundle` is deprecated,
+bundles resolver is used with new format.
+* Upgrade push-snapshot task for v0.6 parameter
+  * addGitShaTag parameter is now supported and passed as a pipeline parameter to the task with value false
+
+## Changes since 0.8
+
+Update tag of ec-task-bundle task
+
+## Changes since 0.7
+
+Pipeline name was changed:
+* metadata.name = `release`
+
+## Changes since 0.6
+
+Pipeline definition was changed:
+* Task `verify-enterprise-contract` now uses the param `STRICT: 1`
+
+## Changes since 0.5
+
+Pipeline definition was changed:
+* Taskref renamed from `verify-enterprise-contract-v2` to `verify-enterprise-contract`
+* Taskref `verify-enterprise-contract` points to new bundle location.
+
+## Changes since 0.4
+
+ Pipeline definition was changed:
+  * Task `apply-mapping` was replaced with `task-apply-mapping`
+  * Task `cleanup-workspace` was replaced with `task-cleanup-workspace`
+
+## Changes since 0.3 (milestone-8)
+
+ Pipeline definition was changed:
+  * Parameter `applicationSnapshot` was changed to `snapshot`
+  * Task `apply-mapping` was changed
+    * Task parameter `applicationSnapshot` value was changed
+      * old: $(params.applicationSnapshot)
+      * new: $(params.snapshot)
+  * Task `prepare-validation` was changed
+    * Task parameter `applicationSnapshot` value was changed
+      * old: $(params.applicationSnapshot)
+      * new: $(params.snapshot)
+  * Task `push-application-snapshot` was changed
+    * Task parameter `mappedApplicationSnapshot` value was changed
+      * old: $(params.mappedApplicationSnapshot)
+      * new: $(params.mappedSnapshot)
+
+## Changes since 0.2 (milestone-6)
+
+* Pipeline definition was changed:
+  * Parameter `policy` was changed to `enterpriseContractPolicy`
+  * Task `verify-enterprise-contract` was changed
+    * Task parameter `POLICY_CONFIGURATION` value was changed
+      * old: $(params.policy)
+      * new: $(params.enterpriseContractPolicy)
+
+## Changes since 0.1 (milestone-5)
+
+* Enterprise Contract task was changed:
+  * Task `prepare-validation` was removed
+  * Task `verify-enterprise-contract` was replaced
+    * old: quay.io/hacbs-release/verify-enterprise-contract:main
+    * new: quay.io/hacbs-release/verify-enterprise-contract-v2:main
+    * Task Parameter `snapshot` was removed
+    * Task parameter `IMAGES` was added
+    * Task Parameter `STRICT` was added
+    * Task Parameter `IMAGE_REF` was removed
+    * Task Parameter `REKOR_HOST` was removed

--- a/catalog/pipeline/release/0.18/README.md
+++ b/catalog/pipeline/release/0.18/README.md
@@ -24,6 +24,7 @@ Tekton pipeline to release Stonesoup Snapshot to Quay.
 * use PipelineRun UID for subdirectory inside the workspace
     * this will avoid the issue of parallel PipelineRuns overriding each other's data
 * also use new version of apply-mapping which overrides the original snapshot_spec file
+    * and specify snapshotPath for this task to point to the subdir
 
 ## Changes since 0.16
 * git resolvers are used in place of release bundle resolvers

--- a/catalog/pipeline/release/0.18/release.yaml
+++ b/catalog/pipeline/release/0.18/release.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: release
   labels:
-    app.kubernetes.io/version: "0.17"
+    app.kubernetes.io/version: "0.18"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -66,7 +66,7 @@ spec:
           - name: revision
             value: main
           - name: pathInRepo
-            value: catalog/task/collect-data/0.1/collect-data.yaml
+            value: catalog/task/collect-data/0.2/collect-data.yaml
       params:
         - name: release
           value: $(params.release)
@@ -78,6 +78,8 @@ spec:
           value: $(params.releasestrategy)
         - name: snapshot
           value: $(params.snapshot)
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
       workspaces:
         - name: data
           workspace: release-workspace
@@ -101,7 +103,7 @@ spec:
         - name: revision
           value: $(params.extraConfigGitRevision)
         - name: subdirectory
-          value: "$(context.pipelineRun.uid)"
+          value: "$(context.pipelineRun.uid)/extraConfig"
       workspaces:
         - name: output
           workspace: release-workspace
@@ -114,10 +116,10 @@ spec:
           - name: revision
             value: main
           - name: pathInRepo
-            value: catalog/task/apply-mapping/0.5/apply-mapping.yaml
+            value: catalog/task/apply-mapping/0.6/apply-mapping.yaml
       params:
         - name: extraConfigPath
-          value: "$(context.pipelineRun.uid)/$(params.extraConfigPath)"
+          value: "$(context.pipelineRun.uid)/extraConfig/$(params.extraConfigPath)"
         - name: failOnEmptyResult
           value: "true"
       when:
@@ -141,7 +143,7 @@ spec:
             value: verify-enterprise-contract
       params:
         - name: IMAGES
-          value: "$(workspaces.data.path)/mapped_snapshot.json"
+          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/snapshot_spec.json"
         - name: SSL_CERT_DIR
           value: /var/run/secrets/kubernetes.io/serviceaccount
         - name: POLICY_CONFIGURATION
@@ -166,6 +168,8 @@ spec:
       params:
         - name: addGitShaTag
           value: $(params.addGitShaTag)
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot_spec.json"
       workspaces:
         - name: data
           workspace: release-workspace

--- a/catalog/pipeline/release/0.18/release.yaml
+++ b/catalog/pipeline/release/0.18/release.yaml
@@ -1,0 +1,197 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: release
+  labels:
+    app.kubernetes.io/version: "0.17"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Tekton pipeline to release HACBS Snapshot to Quay
+  params:
+    - name: release
+      type: string
+      description:
+        The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution
+    - name: releaseplan
+      type: string
+      description: The namespaced name (namespace/name) of the releasePlan
+    - name: releaseplanadmission
+      type: string
+      description: The namespaced name (namespace/name) of the releasePlanAdmission
+    - name: releasestrategy
+      type: string
+      description: The namespaced name (namespace/name) of the releaseStrategy
+    - name: snapshot
+      type: string
+      description: The namespaced name (namespace/name) of the snapshot
+    - name: enterpriseContractPolicy
+      type: string
+      description: JSON representation of the EnterpriseContractPolicy
+    - name: extraConfigGitUrl
+      type: string
+      description: URL to the remote Git repository containing the extra config
+      default: ""
+    - name: extraConfigGitRevision
+      type: string
+      description: Revision to fetch from the remote Git repository containing the extra config
+      default: ""
+    - name: extraConfigPath
+      type: string
+      description: Path to the extra config file within the repository
+      default: ""
+    - name: addGitShaTag
+      type: string
+      description: When pushing the snapshot components, also push a tag with the image git sha
+      default: "true"
+    - name: postCleanUp
+      type: string
+      description: Cleans up workspace after finishing executing the pipeline
+      default: "true"
+    - name: verify_ec_task_bundle
+      type: string
+      description: The location of the bundle containing the verify-enterprise-contract task
+  workspaces:
+    - name: release-workspace
+  tasks:
+    - name: collect-data
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/collect-data/0.1/collect-data.yaml
+      params:
+        - name: release
+          value: $(params.release)
+        - name: releaseplan
+          value: $(params.releaseplan)
+        - name: releaseplanadmission
+          value: $(params.releaseplanadmission)
+        - name: releasestrategy
+          value: $(params.releasestrategy)
+        - name: snapshot
+          value: $(params.snapshot)
+      workspaces:
+        - name: data
+          workspace: release-workspace
+    - name: clone-config-file
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/build-definitions.git
+          - name: revision
+            value: dedce1f59906394ea777606683eec9eb2de465ac
+          - name: pathInRepo
+            value: task/git-clone/0.1/git-clone.yaml
+      when:
+        - input: $(params.extraConfigGitUrl)
+          operator: notin
+          values: [""]
+      params:
+        - name: url
+          value: $(params.extraConfigGitUrl)
+        - name: revision
+          value: $(params.extraConfigGitRevision)
+        - name: subdirectory
+          value: "$(context.pipelineRun.uid)"
+      workspaces:
+        - name: output
+          workspace: release-workspace
+    - name: apply-mapping
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/apply-mapping/0.5/apply-mapping.yaml
+      params:
+        - name: extraConfigPath
+          value: "$(context.pipelineRun.uid)/$(params.extraConfigPath)"
+        - name: failOnEmptyResult
+          value: "true"
+      when:
+        - input: $(tasks.clone-config-file.results.commit)
+          operator: notin
+          values: [""]
+      workspaces:
+        - name: config
+          workspace: release-workspace
+      runAfter:
+        - collect-data
+    - name: verify-enterprise-contract
+      taskRef:
+        resolver: "bundles"
+        params:
+          - name: bundle
+            value: $(params.verify_ec_task_bundle)
+          - name: kind
+            value: task
+          - name: name
+            value: verify-enterprise-contract
+      params:
+        - name: IMAGES
+          value: "$(workspaces.data.path)/mapped_snapshot.json"
+        - name: SSL_CERT_DIR
+          value: /var/run/secrets/kubernetes.io/serviceaccount
+        - name: POLICY_CONFIGURATION
+          value: $(params.enterpriseContractPolicy)
+        - name: STRICT
+          value: "1"
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - apply-mapping
+    - name: push-snapshot
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/push-snapshot/0.9/push-snapshot.yaml
+      params:
+        - name: addGitShaTag
+          value: $(params.addGitShaTag)
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - verify-enterprise-contract
+  finally:
+    - name: cleanup
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/cleanup-workspace/0.2/cleanup-workspace.yaml
+      when:
+        - input: $(params.postCleanUp)
+          operator: in
+          values: ["true"]
+        - input: $(params.extraConfigGitUrl)
+          operator: notin
+          values: [""]
+      params:
+        - name: subdirectory
+          value: "$(context.pipelineRun.uid)"
+      workspaces:
+        - name: input
+          workspace: release-workspace

--- a/catalog/pipeline/release/0.18/release.yaml
+++ b/catalog/pipeline/release/0.18/release.yaml
@@ -122,6 +122,8 @@ spec:
           value: "$(context.pipelineRun.uid)/extraConfig/$(params.extraConfigPath)"
         - name: failOnEmptyResult
           value: "true"
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot_spec.json"
       when:
         - input: $(tasks.clone-config-file.results.commit)
           operator: notin

--- a/catalog/pipeline/release/0.18/release.yaml
+++ b/catalog/pipeline/release/0.18/release.yaml
@@ -190,9 +190,6 @@ spec:
         - input: $(params.postCleanUp)
           operator: in
           values: ["true"]
-        - input: $(params.extraConfigGitUrl)
-          operator: notin
-          values: [""]
       params:
         - name: subdirectory
           value: "$(context.pipelineRun.uid)"

--- a/catalog/pipeline/release/0.18/samples/sample_release_PipelineRun.yaml
+++ b/catalog/pipeline/release/0.18/samples/sample_release_PipelineRun.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: release-run-empty-params
+spec:
+  params:
+    - name: release
+      value: ""
+    - name: releaseplan
+      value: ""
+    - name: releaseplanadmission
+      value: ""
+    - name: releasestrategy
+      value: ""
+    - name: snapshot
+      value: ""
+    - name: enterpriseContractPolicy
+      value: ""
+    - name: extraConfigGitUrl
+      value: ""
+    - name: extraConfigGitRevision
+      value: ""
+    - name: extraConfigPath
+      value: ""
+    - name: postCleanUp
+      value: ""
+    - name: verify_ec_task_bundle
+      value: ""
+  pipelineRef:
+    resolver: "git"
+    params:
+      - name: url
+        value: https://github.com/redhat-appstudio/release-service-bundles.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: catalog/pipeline/release/0.17/release.yaml

--- a/catalog/pipeline/release/0.18/samples/sample_release_PipelineRun.yaml
+++ b/catalog/pipeline/release/0.18/samples/sample_release_PipelineRun.yaml
@@ -35,4 +35,4 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: catalog/pipeline/release/0.17/release.yaml
+        value: catalog/pipeline/release/0.18/release.yaml

--- a/catalog/pipeline/release/0.18/tests/run.yaml
+++ b/catalog/pipeline/release/0.18/tests/run.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: release-run-empty-params
+spec:
+  params:
+    - name: release
+      value: ""
+    - name: releaseplan
+      value: ""
+    - name: releaseplanadmission
+      value: ""
+    - name: releasestrategy
+      value: ""
+    - name: snapshot
+      value: ""
+    - name: enterpriseContractPolicy
+      value: ""
+    - name: extraConfigGitUrl
+      value: ""
+    - name: extraConfigGitRevision
+      value: ""
+    - name: extraConfigPath
+      value: ""
+    - name: postCleanUp
+      value: ""
+    - name: verify_ec_task_bundle
+      value: ""
+  pipelineRef:
+    resolver: "git"
+    params:
+      - name: url
+        value: https://github.com/redhat-appstudio/release-service-bundles.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: catalog/pipeline/release/0.17/release.yaml

--- a/catalog/pipeline/release/0.18/tests/run.yaml
+++ b/catalog/pipeline/release/0.18/tests/run.yaml
@@ -35,4 +35,4 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: catalog/pipeline/release/0.17/release.yaml
+        value: catalog/pipeline/release/0.18/release.yaml

--- a/catalog/pipeline/rhtap-service-push/0.2/README.md
+++ b/catalog/pipeline/rhtap-service-push/0.2/README.md
@@ -31,3 +31,4 @@
 - use PipelineRun UID for subdirectory inside the workspace
     - this will avoid the issue of parallel PipelineRuns overriding each other's data
 - also use new version of apply-mapping which overrides the original snapshot_spec file
+    - and specify snapshotPath for this task to point to the subdir

--- a/catalog/pipeline/rhtap-service-push/0.2/README.md
+++ b/catalog/pipeline/rhtap-service-push/0.2/README.md
@@ -1,0 +1,27 @@
+# RHTAP Service Push to External Registry Pipeline
+
+* Tekton pipeline based on "push-to-external-registry".
+* In addition, it creates a GH pull request in infra-deployments.
+  * The parameter in extraData.infra-deployment-update-script within the ReleasePlanAdmission CR is used to optionally specify a script that can alter files before a PR is created.
+
+## Parameters
+
+| Name | Description | Optional | Default value |
+|------|-------------|----------|---------------|
+| release | The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution | No | - |
+| releaseplan | The namespaced name (namespace/name) of the releasePlan | No | - |
+| releaseplanadmission | The namespaced name (namespace/name) of the releasePlanAdmission | No | - |
+| releasestrategy | The namespaced name (namespace/name) of the releaseStrategy | No | - |
+| snapshot | The namespaced name (namespace/name) of the snapshot | No | - |
+| enterpriseContractPolicy | JSON representation of the policy to be applied when validating the enterprise contract | No | - |
+| extraConfigGitUrl |URL to the remote Git repository containing the extra config | No | - |
+| extraConfigGitRevision | Revision to fetch from the remote Git repository containing the extra config | No | - |
+| extraConfigPath | Path to the extra config file within the repository | No | - |
+| tag | The default tag to use when mapping file does not contain a tag | No | - |
+| addGitShaTag | When pushing the snapshot components, also push a tag with the image git sha | Yes | true |
+| addSourceShaTag | When pushing the snapshot components, also push a tag with the image source sha | Yes | true |
+| addTimestampTag | When pushing the snapshot components, also push a tag with the current timestamp | Yes | false |
+| pyxisServerType | The Pyxis server type to use. Options are 'production' and 'stage' | No | - |
+| pyxisSecret | The kubernetes secret to use to authenticate to Pyxis. It needs to contain two keys: key and cert | No | - |
+| postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
+| verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |

--- a/catalog/pipeline/rhtap-service-push/0.2/README.md
+++ b/catalog/pipeline/rhtap-service-push/0.2/README.md
@@ -25,3 +25,9 @@
 | pyxisSecret | The kubernetes secret to use to authenticate to Pyxis. It needs to contain two keys: key and cert | No | - |
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
+
+## Changes since 0.1
+- use new version of collect-data task with subdirectory parameter
+- use PipelineRun UID for subdirectory inside the workspace
+    - this will avoid the issue of parallel PipelineRuns overriding each other's data
+- also use new version of apply-mapping which overrides the original snapshot_spec file

--- a/catalog/pipeline/rhtap-service-push/0.2/rhtap-service-push.yaml
+++ b/catalog/pipeline/rhtap-service-push/0.2/rhtap-service-push.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rhtap-service-push
   labels:
-    app.kubernetes.io/version: "0.1"
+    app.kubernetes.io/version: "0.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -84,7 +84,7 @@ spec:
           - name: revision
             value: main
           - name: pathInRepo
-            value: catalog/task/collect-data/0.1/collect-data.yaml
+            value: catalog/task/collect-data/0.2/collect-data.yaml
       params:
         - name: release
           value: $(params.release)
@@ -96,6 +96,8 @@ spec:
           value: $(params.releasestrategy)
         - name: snapshot
           value: $(params.snapshot)
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
       workspaces:
         - name: data
           workspace: release-workspace
@@ -119,7 +121,7 @@ spec:
         - name: revision
           value: $(params.extraConfigGitRevision)
         - name: subdirectory
-          value: "$(context.pipelineRun.uid)"
+          value: "$(context.pipelineRun.uid)/extraConfig"
       workspaces:
         - name: output
           workspace: release-workspace
@@ -132,10 +134,10 @@ spec:
           - name: revision
             value: main
           - name: pathInRepo
-            value: catalog/task/apply-mapping/0.5/apply-mapping.yaml
+            value: catalog/task/apply-mapping/0.6/apply-mapping.yaml
       params:
         - name: extraConfigPath
-          value: "$(context.pipelineRun.uid)/$(params.extraConfigPath)"
+          value: "$(context.pipelineRun.uid)/extraConfig/$(params.extraConfigPath)"
         - name: failOnEmptyResult
           value: "true"
       when:
@@ -159,7 +161,7 @@ spec:
             value: verify-enterprise-contract
       params:
         - name: IMAGES
-          value: "$(workspaces.data.path)/mapped_snapshot.json"
+          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/snapshot_spec.json"
         - name: SSL_CERT_DIR
           value: /var/run/secrets/kubernetes.io/serviceaccount
         - name: POLICY_CONFIGURATION
@@ -190,6 +192,8 @@ spec:
           value: $(params.addSourceShaTag)
         - name: addTimestampTag
           value: $(params.addTimestampTag)
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot_spec.json"
       workspaces:
         - name: data
           workspace: release-workspace
@@ -212,6 +216,8 @@ spec:
           value: $(params.pyxisSecret)
         - name: tag
           value: $(params.tag)
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot_spec.json"
       workspaces:
         - name: data
           workspace: release-workspace
@@ -234,6 +240,8 @@ spec:
           value: $(params.pyxisServerType)
         - name: pyxisSecret
           value: $(params.pyxisSecret)
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot_spec.json"
       workspaces:
         - name: data
           workspace: release-workspace
@@ -270,6 +278,8 @@ spec:
       params:
         - name: message
           value: Release pipelineRun $(context.pipelineRun.name) $(tasks.status)
+        - name: extraDataJsonPath
+          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/extra_data.json"
       workspaces:
         - name: data
           workspace: release-workspace

--- a/catalog/pipeline/rhtap-service-push/0.2/rhtap-service-push.yaml
+++ b/catalog/pipeline/rhtap-service-push/0.2/rhtap-service-push.yaml
@@ -297,9 +297,6 @@ spec:
         - input: $(params.postCleanUp)
           operator: in
           values: ["true"]
-        - input: $(params.extraConfigGitUrl)
-          operator: notin
-          values: [""]
       params:
         - name: subdirectory
           value: "$(context.pipelineRun.uid)"

--- a/catalog/pipeline/rhtap-service-push/0.2/rhtap-service-push.yaml
+++ b/catalog/pipeline/rhtap-service-push/0.2/rhtap-service-push.yaml
@@ -1,0 +1,298 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: rhtap-service-push
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Tekton pipeline to release HACBS Snapshot to Quay
+  params:
+    - name: release
+      type: string
+      description:
+        The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution
+    - name: releaseplan
+      type: string
+      description: The namespaced name (namespace/name) of the releasePlan
+    - name: releaseplanadmission
+      type: string
+      description: The namespaced name (namespace/name) of the releasePlanAdmission
+    - name: releasestrategy
+      type: string
+      description: The namespaced name (namespace/name) of the releaseStrategy
+    - name: snapshot
+      type: string
+      description: The namespaced name (namespace/name) of the snapshot
+    - name: enterpriseContractPolicy
+      type: string
+      description: JSON representation of the EnterpriseContractPolicy
+    - name: extraConfigGitUrl
+      type: string
+      description: URL to the remote Git repository containing the extra config
+      default: ""
+    - name: extraConfigGitRevision
+      type: string
+      description: Revision to fetch from the remote Git repository containing the extra config
+      default: ""
+    - name: extraConfigPath
+      type: string
+      description: Path to the extra config file within the repository
+      default: ""
+    - name: tag
+      type: string
+      description: The default tag to use when mapping file does not contain a tag
+    - name: addGitShaTag
+      type: string
+      description: When pushing the snapshot components, also push a tag with the image git sha
+      default: "true"
+    - name: addSourceShaTag
+      type: string
+      description: When pushing the snapshot components, also push a tag with the image source sha
+      default: "true"
+    - name: addTimestampTag
+      type: string
+      description: When pushing the snapshot components, also push a tag with the current timestamp
+      default: "false"
+    - name: pyxisServerType
+      type: string
+      description: The Pyxis server type to use. Options are 'production' and 'stage'
+    - name: pyxisSecret
+      type: string
+      description: |
+        The kubernetes secret to use to authenticate to Pyxis. It needs to contain two keys: key and cert
+    - name: postCleanUp
+      type: string
+      description: Cleans up workspace after finishing executing the pipeline
+      default: "true"
+    - name: verify_ec_task_bundle
+      type: string
+      description: The location of the bundle containing the verify-enterprise-contract task
+  workspaces:
+    - name: release-workspace
+  tasks:
+    - name: collect-data
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/collect-data/0.1/collect-data.yaml
+      params:
+        - name: release
+          value: $(params.release)
+        - name: releaseplan
+          value: $(params.releaseplan)
+        - name: releaseplanadmission
+          value: $(params.releaseplanadmission)
+        - name: releasestrategy
+          value: $(params.releasestrategy)
+        - name: snapshot
+          value: $(params.snapshot)
+      workspaces:
+        - name: data
+          workspace: release-workspace
+    - name: clone-config-file
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/build-definitions.git
+          - name: revision
+            value: dedce1f59906394ea777606683eec9eb2de465ac
+          - name: pathInRepo
+            value: task/git-clone/0.1/git-clone.yaml
+      when:
+        - input: $(params.extraConfigGitUrl)
+          operator: notin
+          values: [""]
+      params:
+        - name: url
+          value: $(params.extraConfigGitUrl)
+        - name: revision
+          value: $(params.extraConfigGitRevision)
+        - name: subdirectory
+          value: "$(context.pipelineRun.uid)"
+      workspaces:
+        - name: output
+          workspace: release-workspace
+    - name: apply-mapping
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/apply-mapping/0.5/apply-mapping.yaml
+      params:
+        - name: extraConfigPath
+          value: "$(context.pipelineRun.uid)/$(params.extraConfigPath)"
+        - name: failOnEmptyResult
+          value: "true"
+      when:
+        - input: $(tasks.clone-config-file.results.commit)
+          operator: notin
+          values: [""]
+      workspaces:
+        - name: config
+          workspace: release-workspace
+      runAfter:
+        - collect-data
+    - name: verify-enterprise-contract
+      taskRef:
+        resolver: "bundles"
+        params:
+          - name: bundle
+            value: $(params.verify_ec_task_bundle)
+          - name: kind
+            value: task
+          - name: name
+            value: verify-enterprise-contract
+      params:
+        - name: IMAGES
+          value: "$(workspaces.data.path)/mapped_snapshot.json"
+        - name: SSL_CERT_DIR
+          value: /var/run/secrets/kubernetes.io/serviceaccount
+        - name: POLICY_CONFIGURATION
+          value: $(params.enterpriseContractPolicy)
+        - name: STRICT
+          value: "1"
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - apply-mapping
+    - name: push-snapshot
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/push-snapshot/0.10/push-snapshot.yaml
+      params:
+        - name: tag
+          value: $(params.tag)
+        - name: addGitShaTag
+          value: $(params.addGitShaTag)
+        - name: addSourceShaTag
+          value: $(params.addSourceShaTag)
+        - name: addTimestampTag
+          value: $(params.addTimestampTag)
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - verify-enterprise-contract
+    - name: create-pyxis-image
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/create-pyxis-image/0.4/create-pyxis-image.yaml
+      params:
+        - name: server
+          value: $(params.pyxisServerType)
+        - name: pyxisSecret
+          value: $(params.pyxisSecret)
+        - name: tag
+          value: $(params.tag)
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - push-snapshot
+    - name: push-sbom-to-pyxis
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/push-sbom-to-pyxis/0.2/push-sbom-to-pyxis.yaml
+      params:
+        - name: containerImageIDs
+          value: $(tasks.create-pyxis-image.results.containerImageIDs)
+        - name: server
+          value: $(params.pyxisServerType)
+        - name: pyxisSecret
+          value: $(params.pyxisSecret)
+      workspaces:
+        - name: data
+          workspace: release-workspace
+    - name: infra-deployments-pr
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/update-infra-deployments/0.1/update-infra-deployments.yaml
+      params:
+        - name: gitImage
+          value: >-
+            quay.io/hacbs-release/release-utils@sha256:5733ece907aa70d6ebced36484c936731e8b27bfcf87fed226a0ecf95047a6b8
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - push-sbom-to-pyxis
+  finally:
+    - name: slack-webhook-notification
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/slack-webhook-notification/0.1/slack-webhook-notification.yaml
+      params:
+        - name: message
+          value: Release pipelineRun $(context.pipelineRun.name) $(tasks.status)
+      workspaces:
+        - name: data
+          workspace: release-workspace
+    - name: cleanup
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/cleanup-workspace/0.2/cleanup-workspace.yaml
+      when:
+        - input: $(params.postCleanUp)
+          operator: in
+          values: ["true"]
+        - input: $(params.extraConfigGitUrl)
+          operator: notin
+          values: [""]
+      params:
+        - name: subdirectory
+          value: "$(context.pipelineRun.uid)"
+      workspaces:
+        - name: input
+          workspace: release-workspace

--- a/catalog/pipeline/rhtap-service-push/0.2/rhtap-service-push.yaml
+++ b/catalog/pipeline/rhtap-service-push/0.2/rhtap-service-push.yaml
@@ -140,6 +140,8 @@ spec:
           value: "$(context.pipelineRun.uid)/extraConfig/$(params.extraConfigPath)"
         - name: failOnEmptyResult
           value: "true"
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot_spec.json"
       when:
         - input: $(tasks.clone-config-file.results.commit)
           operator: notin

--- a/catalog/pipeline/rhtap-service-push/0.2/samples/sample_push-to-external-registry_PipelineRun.yaml
+++ b/catalog/pipeline/rhtap-service-push/0.2/samples/sample_push-to-external-registry_PipelineRun.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: rhtap-service-push-run-empty-params
+spec:
+  params:
+    - name: release
+      value: ""
+    - name: releaseplan
+      value: ""
+    - name: releaseplanadmission
+      value: ""
+    - name: releasestrategy
+      value: ""
+    - name: snapshot
+      value: ""
+    - name: enterpriseContractPolicy
+      value: ""
+    - name: extraConfigGitUrl
+      value: ""
+    - name: extraConfigGitRevision
+      value: ""
+    - name: extraConfigPath
+      value: ""
+    - name: pyxisServerType
+      value: ""
+    - name: pyxisSecret
+      value: ""
+    - name: tag
+      value: ""
+    - name: postCleanUp
+      value: ""
+    - name: verify_ec_task_bundle
+      value: ""
+  pipelineRef:
+    resolver: "git"
+    params:
+      - name: url
+        value: https://github.com/redhat-appstudio/release-service-bundles.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: catalog/pipeline/rhtap-service-push/0.1/rhtap-service-push.yaml

--- a/catalog/pipeline/rhtap-service-push/0.2/samples/sample_push-to-external-registry_PipelineRun.yaml
+++ b/catalog/pipeline/rhtap-service-push/0.2/samples/sample_push-to-external-registry_PipelineRun.yaml
@@ -41,4 +41,4 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: catalog/pipeline/rhtap-service-push/0.1/rhtap-service-push.yaml
+        value: catalog/pipeline/rhtap-service-push/0.2/rhtap-service-push.yaml

--- a/catalog/pipeline/rhtap-service-push/0.2/tests/run.yaml
+++ b/catalog/pipeline/rhtap-service-push/0.2/tests/run.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: rhtap-service-push-run-empty-params
+spec:
+  params:
+    - name: release
+      value: ""
+    - name: releaseplan
+      value: ""
+    - name: releaseplanadmission
+      value: ""
+    - name: releasestrategy
+      value: ""
+    - name: snapshot
+      value: ""
+    - name: enterpriseContractPolicy
+      value: ""
+    - name: extraConfigGitUrl
+      value: ""
+    - name: extraConfigGitRevision
+      value: ""
+    - name: extraConfigPath
+      value: ""
+    - name: pyxisServerType
+      value: ""
+    - name: pyxisSecret
+      value: ""
+    - name: tag
+      value: ""
+    - name: postCleanUp
+      value: ""
+    - name: verify_ec_task_bundle
+      value: ""
+  pipelineRef:
+    resolver: "git"
+    params:
+      - name: url
+        value: https://github.com/redhat-appstudio/release-service-bundles.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: catalog/pipeline/rhtap-service-push/0.1/rhtap-service-push.yaml

--- a/catalog/pipeline/rhtap-service-push/0.2/tests/run.yaml
+++ b/catalog/pipeline/rhtap-service-push/0.2/tests/run.yaml
@@ -41,4 +41,4 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: catalog/pipeline/rhtap-service-push/0.1/rhtap-service-push.yaml
+        value: catalog/pipeline/rhtap-service-push/0.2/rhtap-service-push.yaml

--- a/catalog/task/create-internal-request/0.7/README.md
+++ b/catalog/task/create-internal-request/0.7/README.md
@@ -1,0 +1,38 @@
+# create-internal-request
+
+Creates an InternalRequest resource to call IIB service
+
+## Parameters
+
+| Name | Description | Optional | Default value |
+|------|-------------|----------|---------------|
+| pipelineRunName | The name of the Parent PipelineRun for this task | No | `ir-$(context.pipelineRun.name)` |
+| request | Internal pipeline request name | No | |
+| params | Internal Request parameters | No | |
+| inputDataFile | Optional file to read data from | Yes | "" |
+| updateGenericResult | Should the task update the genericResult result  | Yes | "false" |
+| requestUpdateTimeout | Max seconds to wait until the status is updated | Yes | 360 |
+
+## Changelog
+
+### changes since 0.5
+- adds `updateGenericResult` parameter to control whether the `genericResult`
+  result is updated
+- adds `genericResult` to store data read from the `genericResult` status message
+  from an `InternalRequest`
+- updates `release-base-image` image to latest version
+
+### changes since 0.4
+- full rewrite to accept dynamic parameters
+
+### changes since 0.3
+- removes the additional logging
+- removes `resolvedIndexImage` and `resolvedFromIndexImage` results
+  as now the FBC-Release Pipeline uses `requestResults` to read required values.
+
+### changes since 0.2
+- adds additional logging messages
+
+### changes since 0.1
+- adds `resolvedIndexImage` result
+- adds params `requestUpdateTimeout` and `buildTimeoutSeconds`

--- a/catalog/task/create-internal-request/0.7/README.md
+++ b/catalog/task/create-internal-request/0.7/README.md
@@ -15,6 +15,11 @@ Creates an InternalRequest resource to call IIB service
 
 ## Changelog
 
+### changes since 0.6
+- add new subdirectory parameter to be used for storing of results file
+    - this will enable us to clean up only the current pipelinerun's
+      data in the fbc-release pipeline
+
 ### changes since 0.5
 - adds `updateGenericResult` parameter to control whether the `genericResult`
   result is updated

--- a/catalog/task/create-internal-request/0.7/create-internal-request.yaml
+++ b/catalog/task/create-internal-request/0.7/create-internal-request.yaml
@@ -1,0 +1,182 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: create-internal-request
+  labels:
+    app.kubernetes.io/version: "0.6"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+      Creates an InternalRequest resource to call IIB service
+  params:
+    - name: pipelineRunName
+      type: string
+      description: The name of the Parent PipelineRun of this task
+    - name: request
+      type: string
+      description: request type
+    - name: params
+      type: string
+      description: Internal Request parameters
+    - name: inputDataFile
+      type: string
+      description: Optional file to read data from
+      default: ""
+    - name: updateGenericResult
+      default: "false"
+      description: Should the task update the genericResult result
+    - name: requestUpdateTimeout
+      type: string
+      default: "360"
+      description: Max seconds waiting for the status update
+  results:
+    - name: requestMessage
+      description: Internal Request message
+    - name: requestReason
+      description: Internal Request reason
+    - name: requestResultsFile
+      description: Internal Request results file
+    - name: genericResult
+      description: genericResult field from the InternalRequest Status to expose to the PipelineRun
+  workspaces:
+    - name: input
+      description: Workspace to store the params and responses for the internalRequest
+  steps:
+    - name: prepare-internal-request
+      image:
+        quay.io/hacbs-release/release-utils@sha256:5733ece907aa70d6ebced36484c936731e8b27bfcf87fed226a0ecf95047a6b8
+      script: |
+          #!/usr/bin/env bash
+          #
+          set -e
+          # Tekton wraps the $(param.params) in a JSON string that in some usecases might contain another JSON string
+          # that breaks jq parsing, so we need to sanitize it before parsing it. Currently it supports only single
+          # nested JSON string.
+
+          # sanitize
+          #
+          # param string `file`
+          sanitize() {
+            TEMP="${1}-tmp"
+            # UNESCAPED=$(grep -Po  "(?<=.sanitize.)(.*)+(?=./sanitize.)" ${1})
+            SANITIZED_JSON=$(awk -e \
+                '{match($0, /"{.*}"/, m); 
+                {start=index($0, m[0])+1; end=length(m[0])-2} print substr($0, start, end) }' ${1} | \
+                jq -Rc "." | sed 's|\\|\\\\|g')
+            awk -v sanitized=${SANITIZED_JSON} -e '{gsub(/"{.*}"/, sanitized); gsub("\\\\","\\\\\\"); print}' ${1} \
+            | tee ${TEMP}
+
+            if jq "." ${TEMP} >/dev/null; then
+              mv ${TEMP} ${1}
+            else
+                return 1
+            fi
+          }
+
+          # saving the parameters preserving the string as is
+          JSON_PARAMS="/tmp/json-params-$$.txt"
+          cat > ${JSON_PARAMS} <<JSON
+          $(params.params)
+          JSON
+
+          # sanitizing the string
+          sanitize ${JSON_PARAMS}
+
+          # building the InternalRequest yaml
+          #
+          IR_DIR="$(workspaces.input.path)/internal-request"
+          [ -d "${IR_DIR}" ] || mkdir ${IR_DIR}
+          IR="${IR_DIR}/ir-$(params.pipelineRunName)-$(context.taskRun.uid).yaml"
+          cat > ${IR} <<YAML
+          apiVersion: appstudio.redhat.com/v1alpha1
+          kind: InternalRequest
+          metadata:
+            name: "ir-$(params.pipelineRunName)-$(params.request)"
+          spec:
+            request: "$(params.request)"
+            params:
+          YAML
+
+          LENGTH=`jq ". | length" ${JSON_PARAMS}`
+          for (( i=0; i<${LENGTH}; i++ )); do
+            INPUT=$(jq -r ".[${i}]|[.name, .value]| @tsv" ${JSON_PARAMS})
+            read -r PARAM VALUE <<< "${INPUT}"
+            if [ `jq -e ".[${i}]| has(\"jsonKey\")" ${JSON_PARAMS}` == "true" ]; then
+                JSON_KEY=`jq -r ".[${i}]|[.jsonKey]| @tsv" ${JSON_PARAMS}`
+                # check if the request needs the sharedRequestFile;
+                # otherwise the source is a json string
+                IFS=":" read -r SOURCE TYPE KEY  <<< $VALUE
+                if [ "${SOURCE}" == "sharedRequestFile" ]; then
+                    case ${TYPE} in
+                        "json")
+                            # it has a nested json string
+                            VALUE=`jq -cr "${KEY}" $(params.inputDataFile) \
+                            | jq -cr "${JSON_KEY}"`
+                        ;;
+                    esac
+                else
+                    VALUE=$(echo "${VALUE}" |tr -d "\\" 2>/dev/null |tr -d "\'" |jq -cr "${JSON_KEY}")
+                fi
+            fi
+            echo "    ${PARAM}: \"${VALUE}\"" >> ${IR}
+          done
+    - name: create-internal-request
+      image: 
+        quay.io/hacbs-release/release-utils@sha256:5733ece907aa70d6ebced36484c936731e8b27bfcf87fed226a0ecf95047a6b8
+      script: |
+          #!/usr/bin/env sh
+          PATH=/bin:/usr/bin:/usr/local/bin
+          export PATH
+
+          IR_DIR="$(workspaces.input.path)/internal-request"
+          IR="${IR_DIR}/ir-$(params.pipelineRunName)-$(context.taskRun.uid).yaml"
+          kubectl create -f ${IR}
+    - name: watch-internal-request-status
+      image:
+        quay.io/hacbs-release/release-utils@sha256:5733ece907aa70d6ebced36484c936731e8b27bfcf87fed226a0ecf95047a6b8
+      script: |
+          #!/usr/bin/env sh
+          PATH=/bin:/usr/bin:/usr/local/bin
+          TASKRUN="/tmp/$$.sh"
+
+          cat > ${TASKRUN} <<SH
+          #!/usr/bin/env sh
+          #
+          # the task might need to get input from a shared file
+          IR_DIR="$(workspaces.input.path)/internal-request"
+          RESULTSFILE="\${IR_DIR}/$(params.pipelineRunName)-$(context.taskRun.uid)-results.txt"
+          echo -n \${RESULTSFILE} |tee $(results.requestResultsFile.path)
+
+          IR="ir-$(params.pipelineRunName)-$(params.request)"
+          while true; do
+            STATUS=\$(kubectl get internalrequest \${IR} -o jsonpath='{.status.conditions[0].status}')
+            case "\${STATUS}" in
+              True | False )
+                echo "InternalRequest finished"
+                kubectl get internalrequest \${IR} -o jsonpath='{.status.conditions[0].reason}' \
+                | tee $(results.requestReason.path)
+                kubectl get internalrequest \${IR} -o jsonpath='{.status.conditions[0].message}' \
+                | tee $(results.requestMessage.path)
+                if [ "$(params.updateGenericResult)" == "true" ]; then
+                    kubectl get internalrequest \${IR} -o jsonpath='{.status.results.genericResult}' \
+                    | tee $(results.genericResult.path)
+                fi
+                kubectl get internalrequest \${IR} -o jsonpath='{.status.results}' \
+                | tee \${RESULTSFILE}
+                break
+                ;;
+              "*")
+                ;;
+            esac
+            sleep 30
+          done
+          [ \$(kubectl get internalrequest \${IR} -o jsonpath='{.status.conditions[0].status}') == "True" ]
+          SH
+          chmod +x ${TASKRUN}
+          timeout $(params.requestUpdateTimeout) ${TASKRUN}
+          SYSEXIT=$?
+          [ ${SYSEXIT} -eq 124 ] && echo "Timeout while waiting for the internal request update"
+          exit ${SYSEXIT}

--- a/catalog/task/create-internal-request/0.7/create-internal-request.yaml
+++ b/catalog/task/create-internal-request/0.7/create-internal-request.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-internal-request
   labels:
-    app.kubernetes.io/version: "0.6"
+    app.kubernetes.io/version: "0.7"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -32,6 +32,10 @@ spec:
       type: string
       default: "360"
       description: Max seconds waiting for the status update
+    - name: subdirectory
+      description: Subdirectory inside the workspace to be used
+      type: string
+      default: ""
   results:
     - name: requestMessage
       description: Internal Request message
@@ -63,7 +67,7 @@ spec:
             TEMP="${1}-tmp"
             # UNESCAPED=$(grep -Po  "(?<=.sanitize.)(.*)+(?=./sanitize.)" ${1})
             SANITIZED_JSON=$(awk -e \
-                '{match($0, /"{.*}"/, m); 
+                '{match($0, /"{.*}"/, m);
                 {start=index($0, m[0])+1; end=length(m[0])-2} print substr($0, start, end) }' ${1} | \
                 jq -Rc "." | sed 's|\\|\\\\|g')
             awk -v sanitized=${SANITIZED_JSON} -e '{gsub(/"{.*}"/, sanitized); gsub("\\\\","\\\\\\"); print}' ${1} \
@@ -87,7 +91,7 @@ spec:
 
           # building the InternalRequest yaml
           #
-          IR_DIR="$(workspaces.input.path)/internal-request"
+          IR_DIR="$(workspaces.input.path)/$(params.subdirectory)/internal-request"
           [ -d "${IR_DIR}" ] || mkdir ${IR_DIR}
           IR="${IR_DIR}/ir-$(params.pipelineRunName)-$(context.taskRun.uid).yaml"
           cat > ${IR} <<YAML
@@ -124,14 +128,14 @@ spec:
             echo "    ${PARAM}: \"${VALUE}\"" >> ${IR}
           done
     - name: create-internal-request
-      image: 
+      image:
         quay.io/hacbs-release/release-utils@sha256:5733ece907aa70d6ebced36484c936731e8b27bfcf87fed226a0ecf95047a6b8
       script: |
           #!/usr/bin/env sh
           PATH=/bin:/usr/bin:/usr/local/bin
           export PATH
 
-          IR_DIR="$(workspaces.input.path)/internal-request"
+          IR_DIR="$(workspaces.input.path)/$(params.subdirectory)/internal-request"
           IR="${IR_DIR}/ir-$(params.pipelineRunName)-$(context.taskRun.uid).yaml"
           kubectl create -f ${IR}
     - name: watch-internal-request-status
@@ -146,7 +150,7 @@ spec:
           #!/usr/bin/env sh
           #
           # the task might need to get input from a shared file
-          IR_DIR="$(workspaces.input.path)/internal-request"
+          IR_DIR="$(workspaces.input.path)/$(params.subdirectory)/internal-request"
           RESULTSFILE="\${IR_DIR}/$(params.pipelineRunName)-$(context.taskRun.uid)-results.txt"
           echo -n \${RESULTSFILE} |tee $(results.requestResultsFile.path)
 

--- a/catalog/task/create-internal-request/0.7/samples/sample_create-internal-request_TaskRun.yaml
+++ b/catalog/task/create-internal-request/0.7/samples/sample_create-internal-request_TaskRun.yaml
@@ -21,4 +21,4 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: catalog/task/create-internal-request/0.6/create-internal-request.yaml
+        value: catalog/task/create-internal-request/0.7/create-internal-request.yaml

--- a/catalog/task/create-internal-request/0.7/samples/sample_create-internal-request_TaskRun.yaml
+++ b/catalog/task/create-internal-request/0.7/samples/sample_create-internal-request_TaskRun.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: create-internal-request-run-empty-params
+spec:
+  params:
+    - name: pipelineRunName
+      value: ""
+    - name: request
+      value: ""
+    - name: params
+      value: ""
+    - name: inputDataFile
+      value: ""
+  taskRef:
+    resolver: "git"
+    params:
+      - name: url
+        value: https://github.com/redhat-appstudio/release-service-bundles.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: catalog/task/create-internal-request/0.6/create-internal-request.yaml

--- a/catalog/task/create-internal-request/0.7/tests/run.yaml
+++ b/catalog/task/create-internal-request/0.7/tests/run.yaml
@@ -21,4 +21,4 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: catalog/task/create-internal-request/0.6/create-internal-request.yaml
+        value: catalog/task/create-internal-request/0.7/create-internal-request.yaml

--- a/catalog/task/create-internal-request/0.7/tests/run.yaml
+++ b/catalog/task/create-internal-request/0.7/tests/run.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: create-internal-request-run-empty-params
+spec:
+  params:
+    - name: pipelineRunName
+      value: ""
+    - name: request
+      value: ""
+    - name: params
+      value: ""
+    - name: inputDataFile
+      value: ""
+  taskRef:
+    resolver: "git"
+    params:
+      - name: url
+        value: https://github.com/redhat-appstudio/release-service-bundles.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: catalog/task/create-internal-request/0.6/create-internal-request.yaml


### PR DESCRIPTION
These changes will fix the issue of pipeline runs running in parallel overriding each other's data.

- create new pipeline versions
- use new version of collect-data with subdirectory
- use new version of apply-mapping that overrides original snapshot_spec file
- create new version of create-internal-requests that also uses a subdirectory and use it in the fbc-release pipeline
- make sure all pipelines clean up the subdirectory in the workspace at the end