### PR TITLE
fix: missing ")" after command block

### DIFF
--- a/catalog/task/create-internal-request/0.7/create-internal-request.yaml
+++ b/catalog/task/create-internal-request/0.7/create-internal-request.yaml
@@ -157,7 +157,7 @@ spec:
           IR="ir-$(params.pipelineRunName)-$(params.request)"
           while true; do
             REASON=\$(kubectl get internalrequest \${IR} -o \
-                jsonpath='{.status.conditions[?(@.type=="Succeeded")].reason}'
+                jsonpath='{.status.conditions[?(@.type=="Succeeded")].reason}')
             case "\${REASON}" in
               Succeeded | Failed )
                 echo "InternalRequest finished"


### PR DESCRIPTION
fix: missing ")" char after evaluated command

This PR fixes the missing ")" char after the evaluated command
to get the REASON in the status.

Signed-off-by: Leandro Mendes <lmendes@redhat.com>